### PR TITLE
Some fixes and a little tidying.

### DIFF
--- a/RSDKv5/RSDK/Audio/Audio.cpp
+++ b/RSDKv5/RSDK/Audio/Audio.cpp
@@ -4,7 +4,9 @@
 #include "Legacy/AudioLegacy.cpp"
 #endif
 
+#define STB_VORBIS_NO_PUSHDATA_API
 #define STB_VORBIS_NO_STDIO
+#define STB_VORBIS_NO_INTEGER_CONVERSION
 #include "stb_vorbis/stb_vorbis.c"
 
 stb_vorbis *vorbisInfo = NULL;

--- a/RSDKv5/RSDK/Core/RetroEngine.hpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.hpp
@@ -415,29 +415,12 @@ enum GameRegions {
 #include <GLFW/glfw3.h>
 #endif
 
-#if RETRO_RENDERDEVICE_SDL2
-#ifdef USING_VCPKG
-#include <SDL2/SDL.h>
-#else
-#include <SDL.h>
-#endif // ! USING_VCPKG
-#endif // ! RETRO_RENDERDEVICE_SDL2
-
-#include <theora/theoradec.h>
-
 #endif // ! RETRO_WIN
 
 #if RETRO_PLATFORM == RETRO_OSX
 
-#if RETRO_RENDERDEVICE_SDL2 || RETRO_AUDIODEVICE_SDL2 || RETRO_INPUTDEVICE_SDL2
-#include <SDL2/SDL.h>
-#endif
-
-#include <theora/theoradec.h>
-
 #include "cocoaHelpers.hpp"
 #elif RETRO_PLATFORM == RETRO_iOS
-#include <SDL2/SDL.h>
 
 #include "cocoaHelpers.hpp"
 #elif RETRO_PLATFORM == RETRO_LINUX || RETRO_PLATFORM == RETRO_SWITCH
@@ -450,12 +433,6 @@ enum GameRegions {
 #include <EGL/egl.h> // EGL library
 #include <EGL/eglext.h> // EGL extensions
 #endif
-
-#if RETRO_RENDERDEVICE_SDL2 || RETRO_INPUTDEVICE_SDL2 || RETRO_AUDIODEVICE_SDL2
-#include <SDL2/SDL.h>
-#endif // ! RETRO_RENDERDEVICE_SDL2
-
-#include <theora/theoradec.h>
 
 #if RETRO_PLATFORM == RETRO_SWITCH
 #define PrintConsole _PrintConsole
@@ -471,10 +448,17 @@ enum GameRegions {
 #endif
 
 #include <androidHelpers.hpp>
-#include <theora/theoradec.h>
 
 #undef RETRO_USING_MOUSE
 #endif
+
+#if RETRO_RENDERDEVICE_SDL2 || RETRO_INPUTDEVICE_SDL2 || RETRO_AUDIODEVICE_SDL2
+// This is the way of including SDL that is recommended by the devs themselves:
+// https://wiki.libsdl.org/FAQDevelopment#do_i_include_sdl.h_or_sdlsdl.h
+#include "SDL.h"
+#endif
+
+#include <theora/theoradec.h>
 
 // ============================
 // ENGINE INCLUDES

--- a/RSDKv5/RSDK/Input/Input.hpp
+++ b/RSDKv5/RSDK/Input/Input.hpp
@@ -103,7 +103,7 @@ enum WinMappings {
     KEYMAP_AUTO_MAPPING = -1,
     KEYMAP_NO_MAPPING   = 0,
 
-#if !VK_LBUTTON
+#ifndef VK_LBUTTON
     VK_LBUTTON    = 0x01,
     VK_RBUTTON    = 0x02,
     VK_CANCEL     = 0x03,
@@ -184,7 +184,7 @@ enum WinMappings {
     VK_X = 0x58,
     VK_Y = 0x59,
     VK_Z = 0x5A,
-#if !VK_LBUTTON
+#ifndef VK_LBUTTON
     VK_LWIN                            = 0x5B,
     VK_RWIN                            = 0x5C,
     VK_APPS                            = 0x5D,
@@ -229,6 +229,8 @@ enum WinMappings {
     VK_F22                             = 0x85,
     VK_F23                             = 0x86,
     VK_F24                             = 0x87,
+#endif
+#ifndef VK_NAVIGATION_VIEW
     VK_NAVIGATION_VIEW                 = 0x88,
     VK_NAVIGATION_MENU                 = 0x89,
     VK_NAVIGATION_UP                   = 0x8A,
@@ -237,6 +239,8 @@ enum WinMappings {
     VK_NAVIGATION_RIGHT                = 0x8D,
     VK_NAVIGATION_ACCEPT               = 0x8E,
     VK_NAVIGATION_CANCEL               = 0x8F,
+#endif
+#ifndef VK_LBUTTON
     VK_NUMLOCK                         = 0x90,
     VK_SCROLL                          = 0x91,
     VK_OEM_NEC_EQUAL                   = 0x92,
@@ -276,6 +280,8 @@ enum WinMappings {
     VK_OEM_PERIOD                      = 0xBE,
     VK_OEM_2                           = 0xBF,
     VK_OEM_3                           = 0xC0,
+#endif
+#ifndef VK_GAMEPAD_A
     VK_GAMEPAD_A                       = 0xC3,
     VK_GAMEPAD_B                       = 0xC4,
     VK_GAMEPAD_X                       = 0xC5,
@@ -300,6 +306,8 @@ enum WinMappings {
     VK_GAMEPAD_RIGHT_THUMBSTICK_DOWN   = 0xD8,
     VK_GAMEPAD_RIGHT_THUMBSTICK_RIGHT  = 0xD9,
     VK_GAMEPAD_RIGHT_THUMBSTICK_LEFT   = 0xDA,
+#endif
+#ifndef VK_LBUTTON
     VK_OEM_4                           = 0xDB,
     VK_OEM_5                           = 0xDC,
     VK_OEM_6                           = 0xDD,

--- a/RSDKv5/RSDK/Input/SDL2/SDL2InputDevice.cpp
+++ b/RSDKv5/RSDK/Input/SDL2/SDL2InputDevice.cpp
@@ -208,7 +208,7 @@ RSDK::SKU::InputDeviceSDL *RSDK::SKU::InitSDL2InputDevice(uint32 id, uint8 contr
         controllerType = DEVICE_XBOX;
     else if (strstr(name, "PS4") || strstr(name, "PS5"))
         controllerType = DEVICE_PS4;
-    else if (strstr(name, "Nintendo") || strstr(name, "Switch")) {
+    else if (strstr(name, "Nintendo") || strstr(name, "Switch") || strstr(name, "Wii U")) {
         controllerType   = DEVICE_SWITCH_PRO;
         device->swapABXY = true;
     }

--- a/RSDKv5/RSDK/User/Core/UserCore.cpp
+++ b/RSDKv5/RSDK/User/Core/UserCore.cpp
@@ -117,7 +117,7 @@ void RSDK::SKU::InitUserCore()
     RegisterAchievement("ACH_FBZ", "Window Shopping", "Let the wind take you through");
     RegisterAchievement("ACH_PGZ", "Crate Expectations", "Wreak havoc at the propaganda factory");
     RegisterAchievement("ACH_SSZ", "King of Speed", "Get through Stardust Speedway Zone as quickly as possible");
-    RegisterAchievement("ACH_HCZ", "Boat Enthusiast", "Try pushing a barrel to see how far it goes");
+    RegisterAchievement("ACH_HCZ", "Boat Enthusiast", "We really like boats");
     RegisterAchievement("ACH_MSZ", "The Password is \"Special Stage\"", "Try pushing a barrel to see how far it goes");
     RegisterAchievement("ACH_OOZ", "Secret Sub", "You might have to submerge to find it");
     RegisterAchievement("ACH_LRZ", "Without a Trace", "Barrel through the lava, don't let anything stop you");


### PR DESCRIPTION
This is a stripped-down version of #45, without the endian or Wii U stuff. I can try submitting the endian stuff later, once I know which method would be accepted here.

Since the last PR, I found another way to fix the `KBInputDevice.cpp` issue: `Input.hpp` already contains a partial (broken?) workaround for missing virtual key definitions, so I've just extended the workaround to support cases where some codes are defined while others aren't.