### PR TITLE
Fixed Sound Resuming in dev menu on refocusing

### DIFF
--- a/RSDKv5/RSDK/Core/RetroEngine.cpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.cpp
@@ -126,7 +126,9 @@ int32 RSDK::RunRetroEngine(int32 argc, char *argv[])
             }
             else if (engine.focusState) {
                 engine.focusState = 0;
-                ResumeSound();
+                if(sceneInfo.state != ENGINESTATE_DEVMENU){
+                    ResumeSound();
+                }
             }
 #endif
 


### PR DESCRIPTION
I quickly fixed the sound resuming error in the dev menu I reported in #38. It's certainly not the most elegant solution, though.