### PR TITLE
SDL: Fix deinitialisation.

### DIFF
--- a/RSDKv5/RSDK/Audio/SDL2/SDL2AudioDevice.cpp
+++ b/RSDKv5/RSDK/Audio/SDL2/SDL2AudioDevice.cpp
@@ -46,7 +46,7 @@ void AudioDevice::Release()
     UnlockAudioDevice();
 
     SDL_CloseAudioDevice(AudioDevice::device);
-    SDL_Quit();
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
 }
 
 void AudioDevice::ProcessAudioMixing(void *stream, int32 length)

--- a/RSDKv5/RSDK/Core/RetroEngine.cpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.cpp
@@ -1338,9 +1338,17 @@ void RSDK::InitCoreAPI()
 #ifdef __SWITCH__
     // initNxLink();
 #endif
+
+#if RETRO_RENDERDEVICE_SDL2 || RETRO_AUDIODEVICE_SDL2 || RETRO_INPUTDEVICE_SDL2
+    SDL_Init(0);
+#endif
 }
 void RSDK::ReleaseCoreAPI()
 {
+#if RETRO_RENDERDEVICE_SDL2 || RETRO_AUDIODEVICE_SDL2 || RETRO_INPUTDEVICE_SDL2
+    SDL_Quit();
+#endif
+
 #ifdef __SWITCH__
     // socketExit();
 #endif

--- a/RSDKv5/RSDK/Core/RetroEngine.cpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.cpp
@@ -1327,6 +1327,31 @@ void RSDK::ProcessDebugCommands()
 #endif
 }
 
+#ifdef __SWITCH__
+#include <switch.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/errno.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+static int32 s_nxlinkSock = -1;
+
+static void initNxLink()
+{
+    if (R_FAILED(socketInitializeDefault()))
+        return;
+
+    s_nxlinkSock = nxlinkStdio();
+    if (s_nxlinkSock >= 0)
+        printf("printf output now goes to nxlink server\n");
+    else
+        socketExit();
+}
+#endif
+
 void RSDK::InitCoreAPI()
 {
 #if RETRO_RENDERDEVICE_DIRECTX9 || RETRO_RENDERDEVICE_DIRECTX11

--- a/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
@@ -326,7 +326,7 @@ void RenderDevice::Release(bool32 isRefresh)
         SDL_DestroyWindow(window);
 
     if (!isRefresh)
-        SDL_Quit();
+        SDL_QuitSubSystem(SDL_INIT_VIDEO | SDL_INIT_EVENTS);
 
     if (!isRefresh) {
         if (scanlines)

--- a/RSDKv5/RSDK/Input/Input.cpp
+++ b/RSDKv5/RSDK/Input/Input.cpp
@@ -133,7 +133,12 @@ void RSDK::InitInputDevices()
 #endif
 }
 
-void RSDK::ReleaseInputDevices() {}
+void RSDK::ReleaseInputDevices()
+{
+#if RETRO_INPUTDEVICE_SDL2
+    SKU::ReleaseSDL2InputAPI();
+#endif
+}
 
 void RSDK::ClearInput()
 {

--- a/RSDKv5/RSDK/Input/SDL2/SDL2InputDevice.cpp
+++ b/RSDKv5/RSDK/Input/SDL2/SDL2InputDevice.cpp
@@ -264,3 +264,8 @@ void RSDK::SKU::InitSDL2InputAPI()
         }
     }
 }
+
+void RSDK::SKU::ReleaseSDL2InputAPI()
+{
+	SDL_QuitSubSystem(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC);
+}

--- a/RSDKv5/RSDK/Input/SDL2/SDL2InputDevice.hpp
+++ b/RSDKv5/RSDK/Input/SDL2/SDL2InputDevice.hpp
@@ -41,5 +41,6 @@ struct InputDeviceSDL : InputDevice {
 InputDeviceSDL *InitSDL2InputDevice(uint32 id, uint8 controllerID);
 
 void InitSDL2InputAPI();
+void ReleaseSDL2InputAPI();
 
 } // namespace SKU

--- a/RSDKv5/main.cpp
+++ b/RSDKv5/main.cpp
@@ -1,31 +1,6 @@
 #include "RSDK/Core/RetroEngine.hpp"
 #include "main.hpp"
 
-#ifdef __SWITCH__
-#include <switch.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <sys/errno.h>
-#include <arpa/inet.h>
-#include <unistd.h>
-
-static int32 s_nxlinkSock = -1;
-
-static void initNxLink()
-{
-    if (R_FAILED(socketInitializeDefault()))
-        return;
-
-    s_nxlinkSock = nxlinkStdio();
-    if (s_nxlinkSock >= 0)
-        printf("printf output now goes to nxlink server\n");
-    else
-        socketExit();
-}
-#endif
-
 #if RETRO_STANDALONE
 
 #if RETRO_PLATFORM == RETRO_WIN && !RETRO_RENDERDEVICE_SDL2


### PR DESCRIPTION
Calling `SDL_Quit` twice is not guaranteed to be safe. In fact, it crashes my Wii U port.

If there's a better place to call `SDL_Init` and `SDL_Quit`, then I can move them. By the way, the SDL input backend never deinitialises. Is that something that should be addressed?