### PR TITLE
Fix display with maxPixWidth past 512 (up to 1024)

### DIFF
--- a/RSDKv5/RSDK/Graphics/DX11/DX11RenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/DX11/DX11RenderDevice.cpp
@@ -708,6 +708,9 @@ bool RenderDevice::InitGraphicsAPI()
     }
 
     int32 maxPixHeight = 0;
+#if !RETRO_USE_ORIGINAL_CODE
+    int32 screenWidth = 0;
+#endif
     for (int32 s = 0; s < SCREEN_COUNT; ++s) {
         if (videoSettings.pixHeight > maxPixHeight)
             maxPixHeight = videoSettings.pixHeight;
@@ -715,7 +718,11 @@ bool RenderDevice::InitGraphicsAPI()
         screens[s].size.y = videoSettings.pixHeight;
 
         float viewAspect  = viewSize.x / viewSize.y;
+#if !RETRO_USE_ORIGINAL_CODE
+        screenWidth = (int32)((viewAspect * videoSettings.pixHeight) + 3) & 0xFFFFFFFC;
+#else
         int32 screenWidth = (int32)((viewAspect * videoSettings.pixHeight) + 3) & 0xFFFFFFFC;
+#endif
         if (screenWidth < videoSettings.pixWidth)
             screenWidth = videoSettings.pixWidth;
 
@@ -775,7 +782,11 @@ bool RenderDevice::InitGraphicsAPI()
         dx11Context->RSSetViewports(1, &dx11ViewPort);
     }
 
+#if !RETRO_USE_ORIGINAL_CODE
+    if (screenWidth <= 512 && maxPixHeight <= 256) {
+#else
     if (maxPixHeight <= 256) {
+#endif
         textureSize.x = 512.0;
         textureSize.y = 256.0;
     }

--- a/RSDKv5/RSDK/Graphics/DX9/DX9RenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/DX9/DX9RenderDevice.cpp
@@ -599,6 +599,9 @@ bool RenderDevice::InitGraphicsAPI()
     }
 
     int32 maxPixHeight = 0;
+#if !RETRO_USE_ORIGINAL_CODE
+    int32 screenWidth = 0;
+#endif
     for (int32 s = 0; s < SCREEN_COUNT; ++s) {
         if (videoSettings.pixHeight > maxPixHeight)
             maxPixHeight = videoSettings.pixHeight;
@@ -606,7 +609,11 @@ bool RenderDevice::InitGraphicsAPI()
         screens[s].size.y = videoSettings.pixHeight;
 
         float viewAspect  = viewSize.x / viewSize.y;
+#if !RETRO_USE_ORIGINAL_CODE
+        screenWidth = (int32)((viewAspect * videoSettings.pixHeight) + 3) & 0xFFFFFFFC;
+#else
         int32 screenWidth = (int32)((viewAspect * videoSettings.pixHeight) + 3) & 0xFFFFFFFC;
+#endif
         if (screenWidth < videoSettings.pixWidth)
             screenWidth = videoSettings.pixWidth;
 
@@ -646,7 +653,11 @@ bool RenderDevice::InitGraphicsAPI()
         dx9Device->SetViewport(&dx9ViewPort);
     }
 
+#if !RETRO_USE_ORIGINAL_CODE
+    if (screenWidth <= 512 && maxPixHeight <= 256) {
+#else
     if (maxPixHeight <= 256) {
+#endif
         textureSize.x = 512.0;
         textureSize.y = 256.0;
     }

--- a/RSDKv5/RSDK/Graphics/EGL/EGLRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/EGL/EGLRenderDevice.cpp
@@ -283,7 +283,7 @@ bool RenderDevice::InitGraphicsAPI()
     videoSettings.fsWidth  = 1920;
     videoSettings.fsHeight = 1080;
 #elif RETRO_PLATFORM == RETRO_ANDROID
-    customSettings.maxPixWidth = 510;
+    customSettings.maxPixWidth = 0;
     videoSettings.fsWidth      = 0;
     videoSettings.fsHeight     = 0;
 #endif
@@ -314,6 +314,9 @@ bool RenderDevice::InitGraphicsAPI()
     }
 
     int32 maxPixHeight = 0;
+#if !RETRO_USE_ORIGINAL_CODE
+    int32 screenWidth = 0;
+#endif
     for (int32 s = 0; s < SCREEN_COUNT; ++s) {
         if (videoSettings.pixHeight > maxPixHeight)
             maxPixHeight = videoSettings.pixHeight;
@@ -321,7 +324,11 @@ bool RenderDevice::InitGraphicsAPI()
         screens[s].size.y = videoSettings.pixHeight;
 
         float viewAspect  = viewSize.x / viewSize.y;
+#if !RETRO_USE_ORIGINAL_CODE
+        screenWidth = (int32)((viewAspect * videoSettings.pixHeight) + 3) & 0xFFFFFFFC;
+#else
         int32 screenWidth = (int32)((viewAspect * videoSettings.pixHeight) + 3) & 0xFFFFFFFC;
+#endif
         if (screenWidth < videoSettings.pixWidth)
             screenWidth = videoSettings.pixWidth;
 
@@ -357,7 +364,11 @@ bool RenderDevice::InitGraphicsAPI()
         viewportSize.x = (pixAspect * viewSize.y);
     }
 
+#if !RETRO_USE_ORIGINAL_CODE
+    if (screenWidth <= 512 && maxPixHeight <= 256) {
+#else
     if (maxPixHeight <= 256) {
+#endif
         textureSize.x = 512.0;
         textureSize.y = 256.0;
     }

--- a/RSDKv5/RSDK/Graphics/GLFW/GLFWRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/GLFW/GLFWRenderDevice.cpp
@@ -217,6 +217,9 @@ bool RenderDevice::InitGraphicsAPI()
     }
 
     int32 maxPixHeight = 0;
+#if !RETRO_USE_ORIGINAL_CODE
+    int32 screenWidth = 0;
+#endif
     for (int32 s = 0; s < SCREEN_COUNT; ++s) {
         if (videoSettings.pixHeight > maxPixHeight)
             maxPixHeight = videoSettings.pixHeight;
@@ -224,7 +227,11 @@ bool RenderDevice::InitGraphicsAPI()
         screens[s].size.y = videoSettings.pixHeight;
 
         float viewAspect  = viewSize.x / viewSize.y;
+#if !RETRO_USE_ORIGINAL_CODE
+        screenWidth = (int32)((viewAspect * videoSettings.pixHeight) + 3) & 0xFFFFFFFC;
+#else
         int32 screenWidth = (int32)((viewAspect * videoSettings.pixHeight) + 3) & 0xFFFFFFFC;
+#endif
         if (screenWidth < videoSettings.pixWidth)
             screenWidth = videoSettings.pixWidth;
 
@@ -263,7 +270,11 @@ bool RenderDevice::InitGraphicsAPI()
         viewportSize.x = (pixAspect * viewSize.y);
     }
 
+#if !RETRO_USE_ORIGINAL_CODE
+    if (screenWidth <= 512 && maxPixHeight <= 256) {
+#else
     if (maxPixHeight <= 256) {
+#endif
         textureSize.x = 512.0;
         textureSize.y = 256.0;
     }

--- a/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
@@ -475,6 +475,9 @@ bool RenderDevice::InitGraphicsAPI()
     SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 
     int32 maxPixHeight = 0;
+#if !RETRO_USE_ORIGINAL_CODE
+    int32 screenWidth = 0;
+#endif
     for (int32 s = 0; s < 4; ++s) {
         if (videoSettings.pixHeight > maxPixHeight)
             maxPixHeight = videoSettings.pixHeight;
@@ -482,7 +485,11 @@ bool RenderDevice::InitGraphicsAPI()
         screens[s].size.y = videoSettings.pixHeight;
 
         float viewAspect  = viewSize.x / viewSize.y;
+#if !RETRO_USE_ORIGINAL_CODE
+        screenWidth = (int32)((viewAspect * videoSettings.pixHeight) + 3) & 0xFFFFFFFC;
+#else
         int32 screenWidth = (int32)((viewAspect * videoSettings.pixHeight) + 3) & 0xFFFFFFFC;
+#endif
         if (screenWidth < videoSettings.pixWidth)
             screenWidth = videoSettings.pixWidth;
 
@@ -504,7 +511,11 @@ bool RenderDevice::InitGraphicsAPI()
     SDL_RenderSetLogicalSize(renderer, videoSettings.pixWidth, SCREEN_YSIZE);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
 
+#if !RETRO_USE_ORIGINAL_CODE
+    if (screenWidth <= 512 && maxPixHeight <= 256) {
+#else
     if (maxPixHeight <= 256) {
+#endif
         textureSize.x = 512.0;
         textureSize.y = 256.0;
     }


### PR DESCRIPTION
By default, setting maxPixWidth past 512 will cause stretching on the right side of the screen, getting worse the wider you go. This PR makes it so RSDKv5 will check for both screenWidth and maxPixHeight to determine if the texture size should be 512x256 or 1024x512, eliminating the stretching issue until you set maxPixWidth past 1024.

Default (424):
![2022-08-29_16-11-35_RSDKv5U](https://user-images.githubusercontent.com/15317421/187314604-529be007-5075-4ebd-825d-c3d28d7e5675.png)

Maximum (512):
![2022-08-29_16-11-43_RSDKv5U](https://user-images.githubusercontent.com/15317421/187314610-6e054349-07d3-4b3e-930f-5d9dae84ea07.png)

Past Maximum (576):
![2022-08-29_16-12-23_RSDKv5U_old](https://user-images.githubusercontent.com/15317421/187314616-4b7b79f9-dd62-4660-83df-5dbdc09ee80b.png)

Past Maximum in PR:
![2022-08-29_16-12-32_RSDKv5U](https://user-images.githubusercontent.com/15317421/187314619-9682d146-89a7-4f49-bbed-ed4b3c49bd0e.png)

New Maximum (1024):
![so ma](https://user-images.githubusercontent.com/15317421/187314620-48976881-bba3-475b-ab77-016ec302bb57.png)

New Maximum with PR:
![2022-08-29_16-12-50_RSDKv5U](https://user-images.githubusercontent.com/15317421/187314624-e36db7db-fcc8-485d-a4cb-5a0480ff516b.png)