### PR TITLE
Change default mod target version.

### DIFF
--- a/RSDKv5/RSDK/Core/ModAPI.cpp
+++ b/RSDKv5/RSDK/Core/ModAPI.cpp
@@ -474,7 +474,7 @@ bool32 RSDK::LoadMod(ModInfo *info, std::string modsPath, std::string folder, bo
 
         info->forceVersion = iniparser_getint(ini, ":ForceVersion", 0);
         if (!info->forceVersion) {
-            info->targetVersion = iniparser_getint(ini, ":TargetVersion", 0);
+            info->targetVersion = iniparser_getint(ini, ":TargetVersion", -1);
             if (info->targetVersion != -1 && ENGINE_VERSION) {
                 if (info->targetVersion < 3 || info->targetVersion > 5) {
                     PrintLog(PRINT_NORMAL, "[MOD] Invalid target version. Should be 3, 4, or 5");


### PR DESCRIPTION
Assuming 0 by default causes mods that don't define `TargetVersion` in their `mod.ini` file to not load, as their assumed target version of 0 will not match the version of the engine. -1 bypasses the version check entirely, which I imagine is preferable to the mod not working at all.