### PR TITLE
Add SDL2 controller mappings from gamecontrollerdb.txt

### DIFF
--- a/RSDKv5/RSDK/Input/SDL2/SDL2InputDevice.cpp
+++ b/RSDKv5/RSDK/Input/SDL2/SDL2InputDevice.cpp
@@ -235,6 +235,7 @@ RSDK::SKU::InputDeviceSDL *RSDK::SKU::InitSDL2InputDevice(uint32 id, SDL_GameCon
 
 void RSDK::SKU::InitSDL2InputAPI()
 {
+    SDL_GameControllerAddMappingsFromFile("gamecontrollerdb.txt");
     SDL_InitSubSystem(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC);
 
     return;


### PR DESCRIPTION
This allows for controller mappings to be loaded that aren't in the default SDL2 database.