### PR TITLE
Minor tweaks, a fix, enable `SDL_OpenURL`, and add my Wii U fork to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Currently, the only officially supported platforms are the ones listed above. Ho
 * ### [WebASM](https://github.com/heyjoeway/RSDKv5-Decompilation/tree/emscripten) by heyjoeway 
 * ### [New 3DS](https://github.com/SaturnSH2x2/RSDKv5-Decompilation/tree/3ds-main) by SaturnSH2x2
 * ### [Wii U](https://github.com/Radfordhound/RSDKv5-Decompilation) by Radfordhound
+* ### [Wii U](https://github.com/Clownacy/Sonic-Mania-Decompilation) by Clownacy
 * ### [Vita](https://github.com/SonicMastr/Sonic-Mania-Vita) by SonicMastr
 * #### and a [general optimization fork](https://github.com/smb123w64gb/RSDKv5-Decompilation) by smb123w64gb
 

--- a/RSDKv5/RSDK/Graphics/Drawing.cpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.cpp
@@ -241,15 +241,15 @@ void RSDK::RenderDeviceBase::ProcessDimming()
     // initialize dimLimit before ProcessStage(), maybe in RenderDevice::SetupRendering() or something
 
     if (videoSettings.dimTimer < videoSettings.dimLimit) {
-        if (videoSettings.dimPercent < 1.0) {
+        if (videoSettings.dimPercent < 1.0f) {
             videoSettings.dimPercent += 0.05f;
 
-            if (videoSettings.dimPercent > 1.0)
-                videoSettings.dimPercent = 1.0;
+            if (videoSettings.dimPercent > 1.0f)
+                videoSettings.dimPercent = 1.0f;
         }
     }
     else {
-        if (videoSettings.dimPercent > 0.25)
+        if (videoSettings.dimPercent > 0.25f)
             videoSettings.dimPercent *= 0.9f;
     }
 }

--- a/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
@@ -293,10 +293,10 @@ void RenderDevice::FlipScreen()
 #endif
     }
 #endif
-    SDL_SetRenderTarget(renderer, NULL);
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0xFF - (dimAmount * 0xFF));
-    if (dimAmount < 1.0)
+    if (dimAmount < 1.0f) {
+        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0xFF - (dimAmount * 0xFF));
         SDL_RenderFillRect(renderer, NULL);
+    }
     // no change here
     SDL_RenderPresent(renderer);
 }

--- a/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
@@ -108,6 +108,7 @@ void RenderDevice::FlipScreen()
 
     // Clear the screen. This is needed to keep the
     // pillarboxes in fullscreen from displaying garbage data.
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0xFF);
     SDL_RenderClear(renderer);
 
 #if (SDL_COMPILEDVERSION >= SDL_VERSIONNUM(2, 0, 18))

--- a/RSDKv5/RSDK/User/Dummy/DummyCore.cpp
+++ b/RSDKv5/RSDK/User/Dummy/DummyCore.cpp
@@ -110,9 +110,8 @@ bool32 DummyCore::GetConfirmButtonFlip() { return GetAPIValue(GetAPIValueID("SYS
 void DummyCore::LaunchManual()
 {
     // LaunchManual() just opens the mania manual URL, thats it
-#if RETRO_RENDERDEVICE_SDL2
-    // SDL_OpenURL("http://www.sonicthehedgehog.com/mania/manual");
-    PrintLog(PRINT_NORMAL, "DUMMY LaunchManual()");
+#if RETRO_RENDERDEVICE_SDL2 || RETRO_AUDIODEVICE_SDL2 || RETRO_INPUTDEVICE_SDL2
+    SDL_OpenURL("http://www.sonicthehedgehog.com/mania/manual");
 #else
     PrintLog(PRINT_NORMAL, "EMPTY LaunchManual()");
 #endif


### PR DESCRIPTION
Hi. The tweaks are just some adjustments that I made downstream, and I figured that I might as well upstream them if possible.

I'm not sure why `SDL_OpenURL` was disabled, so if there's a reason that I'm missing, I wouldn't mind leaving this as a downstream-only modification. The platform that my port runs on supports `SDL_OpenURL`, so I find it useful to have enabled.

I also added my port to the list of forks in the readme, since I think that it's more or less complete now.