### PR TITLE
Remove GLFW3 from Switch Makefile.

### DIFF
--- a/makefiles/Switch.cfg
+++ b/makefiles/Switch.cfg
@@ -30,11 +30,11 @@ PKG_SUFFIX  = .nro
 SUBSYSTEM ?= GL3
 
 ifeq ($(SUBSYSTEM),GL3) 
-	# VIDEO: GL3/GLFW
+	# VIDEO: GL3/EGL
 	# INPUTS: Switch
 	# AUDIO: SDL2
 	RSDK_CFLAGS += `$(PKGCONFIG) --cflags --static sdl2`
-	RSDK_LIBS += `$(PKGCONFIG) --libs --static sdl2` -lglfw3 -lglad
+	RSDK_LIBS += `$(PKGCONFIG) --libs --static sdl2` -lglad
 endif
 
 ifeq ($(SUBSYSTEM),SDL2)


### PR DESCRIPTION
The Switch port uses EGL instead of GLFW3.