### PR TITLE
Fix stack corruption

### DIFF
--- a/RSDKv5/RSDK/Core/Reader.hpp
+++ b/RSDKv5/RSDK/Core/Reader.hpp
@@ -416,6 +416,7 @@ inline int32 Uncompress(uint8 **cBuffer, int32 cSize, uint8 **buffer, int32 size
     return (int32)destLen;
 }
 
+// The buffer passed in parameter is allocated here, so it's up to the caller to free it once it goes unused
 inline int32 ReadCompressed(FileInfo *info, uint8 **buffer)
 {
     if (!buffer)

--- a/RSDKv5/RSDK/Graphics/Sprite.cpp
+++ b/RSDKv5/RSDK/Graphics/Sprite.cpp
@@ -633,7 +633,7 @@ bool32 RSDK::ImagePNG::Load(const char *fileName, bool32 loadHeader)
 
                         // read this chunk into the chunk buffer storage (we're processing each IDAT section by itself
                         // this is a BAD idea!!! though it's kept here for reference as to how the original v5 works
-                        AllocateStorage(chunkSize, (void **)&chunkBuffer, DATASET_TMP, false);
+                        AllocateStorage((void **)&chunkBuffer, chunkSize, DATASET_TMP, false);
                         ReadBytes(&info, chunkBuffer, chunkSize);
 
                         // decode the scanlines into usable RGBA pixels
@@ -951,16 +951,20 @@ uint16 RSDK::LoadSpriteSheet(const char *filename, int32 scope)
         image.pixels = surface->pixels;
         image.Load(NULL, false);
 
+#if RETRO_USE_ORIGINAL_CODE
         image.palette = NULL;
         image.decoder = NULL;
+#endif
         image.Close();
 
         return id;
     }
     else {
+#if RETRO_USE_ORIGINAL_CODE
         image.palette = NULL;
-        image.pixels  = NULL;
         image.decoder = NULL;
+#endif
+        image.pixels  = NULL;
         image.Close();
         return -1;
     }
@@ -999,7 +1003,9 @@ bool32 RSDK::LoadImage(const char *filename, double displayLength, double fadeSp
         sceneInfo.state           = ENGINESTATE_SHOWIMAGE;
         engine.imageFadeSpeed     = fadeSpeed / 60.0;
 
+#if RETRO_USE_ORIGINAL_CODE
         image.palette = NULL;
+#endif
         image.pixels  = NULL;
         image.Close();
         return true;
@@ -1025,14 +1031,18 @@ bool32 RSDK::LoadImage(const char *filename, double displayLength, double fadeSp
         sceneInfo.state           = ENGINESTATE_SHOWIMAGE;
         engine.imageFadeSpeed     = fadeSpeed / 60.0;
 
+#if RETRO_USE_ORIGINAL_CODE
         image.palette = NULL;
+#endif
         image.pixels  = NULL;
         image.Close();
         return true;
     }
 #endif
     else {
+#if RETRO_USE_ORIGINAL_CODE
         image.palette = NULL;
+#endif
         image.pixels  = NULL;
         image.Close();
     }

--- a/RSDKv5/RSDK/Graphics/Sprite.hpp
+++ b/RSDKv5/RSDK/Graphics/Sprite.hpp
@@ -13,6 +13,9 @@ struct Image {
         palette = NULL;
         pixels  = NULL;
     }
+#if !RETRO_USE_ORIGINAL_CODE
+    ~Image() { RemoveStorageEntry((void **)&palette); }
+#endif
 
     virtual bool32 Load(const char *fileName, bool32 loadHeader) { return false; }
     virtual bool32 Load(String *fileName, bool32 loadHeader)
@@ -57,6 +60,9 @@ struct GifDecoder {
 
 struct ImageGIF : public Image {
     ImageGIF() { AllocateStorage((void **)&decoder, sizeof(GifDecoder), DATASET_TMP, true); }
+#if !RETRO_USE_ORIGINAL_CODE
+    ~ImageGIF() { RemoveStorageEntry((void **)&decoder); }
+#endif
 
     bool32 Load(const char *fileName, bool32 loadHeader);
 

--- a/RSDKv5/RSDK/Scene/Legacy/SceneLegacy.cpp
+++ b/RSDKv5/RSDK/Scene/Legacy/SceneLegacy.cpp
@@ -314,8 +314,10 @@ void RSDK::Legacy::LoadStageGIFFile()
             SetPaletteEntry(-1, c, red, green, blue);
         }
 
+#if RETRO_USE_ORIGINAL_CODE
         tileset.palette = NULL;
         tileset.decoder = NULL;
+#endif
         tileset.pixels  = NULL;
 
         tileset.Close();

--- a/RSDKv5/RSDK/Scene/Scene.cpp
+++ b/RSDKv5/RSDK/Scene/Scene.cpp
@@ -420,6 +420,9 @@ void RSDK::LoadSceneAssets()
             uint8 *scrollIndexes = NULL;
             ReadCompressed(&info, (uint8 **)&scrollIndexes);
             memcpy(layer->lineScroll, scrollIndexes, TILE_SIZE * size * sizeof(uint8));
+#if !RETRO_USE_ORIGINAL_CODE
+            RemoveStorageEntry((void **)&scrollIndexes);
+#endif
             scrollIndexes = NULL;
 
             uint8 *tileLayout = NULL;
@@ -433,6 +436,9 @@ void RSDK::LoadSceneAssets()
                 }
             }
 
+#if !RETRO_USE_ORIGINAL_CODE
+            RemoveStorageEntry((void **)&tileLayout);
+#endif
             tileLayout = NULL;
         }
 
@@ -650,6 +656,11 @@ void RSDK::LoadSceneAssets()
                     }
                 }
             }
+
+#if !RETRO_USE_ORIGINAL_CODE
+            RemoveStorageEntry((void **)&varList);
+            varList = NULL;
+#endif
         }
 
 #if RETRO_REV02
@@ -680,9 +691,15 @@ void RSDK::LoadSceneAssets()
                 break;
         }
 
+#if !RETRO_USE_ORIGINAL_CODE
+        RemoveStorageEntry((void **)&tempEntityList);
+#endif
         tempEntityList = NULL;
 #endif
 
+#if !RETRO_USE_ORIGINAL_CODE
+        RemoveStorageEntry((void **)&editableVarList);
+#endif
         editableVarList = NULL;
 
         CloseFile(&info);
@@ -921,6 +938,10 @@ void RSDK::LoadTileConfig(char *filepath)
             }
         }
 
+#if !RETRO_USE_ORIGINAL_CODE
+        RemoveStorageEntry((void **)&buffer);
+        buffer = NULL;
+#endif
         CloseFile(&info);
     }
 }
@@ -979,8 +1000,10 @@ void RSDK::LoadStageGIF(char *filepath)
             dstPixels += (TILE_SIZE * 2);
         }
 
+#if RETRO_USE_ORIGINAL_CODE
         tileset.palette = NULL;
         tileset.decoder = NULL;
+#endif
         tileset.pixels  = NULL;
     }
 }


### PR DESCRIPTION
Fixes errors found by AddressSanitizer (use-after-scope) because of dangling pointers to the stack.
This prevents the allocator from trying to free the wrong allocation, which would lead to stack corruption.

`Image::pixels` are not freed at the moment, as they would sometimes be pointing to global variables.

Fixes #106.