### PR TITLE
Fix gamePadMappings memory leak

### DIFF
--- a/RSDKv5/RSDK/User/Core/UserCore.cpp
+++ b/RSDKv5/RSDK/User/Core/UserCore.cpp
@@ -419,10 +419,16 @@ void RSDK::LoadSettingsINI()
         }
 
 #if !RETRO_USE_ORIGINAL_CODE
-        // using standard allocation here due to mod loader trickery
-        gamePadMappings = new GamePadMappings[gamePadCount];
+        if (gamePadCount) {
+#endif
+#if RETRO_USE_MOD_LOADER
+            // using standard allocation here due to mod loader trickery
+            gamePadMappings = new GamePadMappings[gamePadCount];
 #else
-        AllocateStorage((void **)&gamePadMappings, sizeof(GamePadMappings) * gamePadCount, DATASET_STG, true);
+            AllocateStorage((void **)&gamePadMappings, sizeof(GamePadMappings) * gamePadCount, DATASET_STG, true);
+#endif
+#if !RETRO_USE_ORIGINAL_CODE
+        }
 #endif
 
         for (int32 i = 0; i < gamePadCount; ++i) {
@@ -720,7 +726,7 @@ void RSDK::SaveSettingsINI(bool32 writeToFile)
         fClose(file);
     }
 
-#if !RETRO_USE_ORIGINAL_CODE
+#if RETRO_USE_MOD_LOADER
     if (gamePadCount && gamePadMappings)
         delete[] gamePadMappings;
     gamePadMappings = NULL;


### PR DESCRIPTION
This array was allocated using `new` even if the mod loader was disabled, and the size used for the allocation was never checked to be valid.

Only allocate/free when mod loader is enabled, and add a size check.

ASan on Linux showed a 1 byte leak when `gamePadCount==0`, who knows what was happening on other platforms.