### PR TITLE
Various memory allocation fixes

### DIFF
--- a/RSDKv5/RSDK/Storage/Storage.cpp
+++ b/RSDKv5/RSDK/Storage/Storage.cpp
@@ -87,7 +87,13 @@ void RSDK::AllocateStorage(void **dataPtr, uint32 size, StorageDataSets dataSet,
         if (dataStorage[dataSet].entryCount < STORAGE_ENTRY_COUNT) {
             DataStorage *storage = &dataStorage[dataSet];
 
+#if !RETRO_USE_ORIGINAL_CODE
+            // Bug: The original release never takes into account the size of the header when checking if there's enough storage left.
+            // Omitting this will overflow the memory pool when (storageLimit - usedStorage + size) < header size (16 bytes here).
+            if (storage->usedStorage * sizeof(uint32) + size + (HEADER_SIZE * sizeof(uint32)) < storage->storageLimit) {
+#else
             if (storage->usedStorage * sizeof(uint32) + size < storage->storageLimit) {
+#endif
                 // HEADER_ACTIVE
                 storage->memoryTable[storage->usedStorage] = true;
                 ++storage->usedStorage;
@@ -118,7 +124,11 @@ void RSDK::AllocateStorage(void **dataPtr, uint32 size, StorageDataSets dataSet,
 
                 // If there is now room, then perform allocation.
                 // Yes, this really is a massive chunk of duplicate code.
+#if !RETRO_USE_ORIGINAL_CODE
+                if (storage->usedStorage * sizeof(uint32) + size + (HEADER_SIZE * sizeof(uint32)) < storage->storageLimit) {
+#else
                 if (storage->usedStorage * sizeof(uint32) + size < storage->storageLimit) {
+#endif
                     // HEADER_ACTIVE
                     storage->memoryTable[storage->usedStorage] = true;
                     ++storage->usedStorage;

--- a/RSDKv5/RSDK/User/Core/UserAchievements.cpp
+++ b/RSDKv5/RSDK/User/Core/UserAchievements.cpp
@@ -123,6 +123,9 @@ void RSDK::SKU::ProcessAchievements()
                     InitString(&achievementStrings[0], achievementText.c_str(), 0);
                     String buffer;
                     CopyString(&achievementStrings[1], achievements->GetAchievementName(&buffer, achievementID));
+#if !RETRO_USE_ORIGINAL_CODE
+                    RemoveStorageEntry((void**)&buffer);
+#endif
 
                     if (curSKU.language == LANGUAGE_JP) {
                         achievementStringWidth[0] = 13 * achievementStrings[0].length;
@@ -158,6 +161,9 @@ void RSDK::SKU::DrawAchievements()
             InitString(&achievementStrings[0], achievementText.c_str(), 0);
             String buffer;
             CopyString(&achievementStrings[1], achievements->GetAchievementName(&buffer, achievementID));
+#if !RETRO_USE_ORIGINAL_CODE
+            RemoveStorageEntry((void**)&buffer);
+#endif
 
             int32 drawX = achievementStrX + currentScreen->size.x - achievementStrW;
             DrawRectangle(drawX, currentScreen->size.y - 40, achievementStrW - achievementStrX, 40, 0xFF107C, 0x10, INK_NONE, true);


### PR DESCRIPTION
The allocator never takes into account the size of the header when allocating a new entry.
While not in the original release, this oversight can lead to a buffer overflow.

In `UserAchievements`, local variables allocated by GetAchievementName weren't freed after use, which lead to allocation errors much later (similar to #120).