### PR TITLE
Fix F1/F2 dev functions not checking for listPos overflowing/underflowing

### DIFF
--- a/RSDKv5/RSDK/Graphics/DX11/DX11RenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/DX11/DX11RenderDevice.cpp
@@ -1493,7 +1493,8 @@ void RenderDevice::ProcessEvent(MSG Msg)
                 case VK_F1:
                     if (engine.devMenu) {
                         sceneInfo.listPos--;
-                        if (sceneInfo.listPos < sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetStart) {
+                        if (sceneInfo.listPos < sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetStart
+                            || sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd) {
                             sceneInfo.activeCategory--;
                             if (sceneInfo.activeCategory >= sceneInfo.categoryCount) {
                                 sceneInfo.activeCategory = sceneInfo.categoryCount - 1;
@@ -1517,7 +1518,7 @@ void RenderDevice::ProcessEvent(MSG Msg)
                 case VK_F2:
                     if (engine.devMenu) {
                         sceneInfo.listPos++;
-                        if (sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd) {
+                        if (sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd || sceneInfo.listPos == 0) {
                             sceneInfo.activeCategory++;
                             if (sceneInfo.activeCategory >= sceneInfo.categoryCount) {
                                 sceneInfo.activeCategory = 0;

--- a/RSDKv5/RSDK/Graphics/DX9/DX9RenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/DX9/DX9RenderDevice.cpp
@@ -1169,7 +1169,8 @@ void RenderDevice::ProcessEvent(MSG Msg)
                 case VK_F1:
                     if (engine.devMenu) {
                         sceneInfo.listPos--;
-                        if (sceneInfo.listPos < sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetStart) {
+                        if (sceneInfo.listPos < sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetStart
+                            || sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd) {
                             sceneInfo.activeCategory--;
                             if (sceneInfo.activeCategory >= sceneInfo.categoryCount) {
                                 sceneInfo.activeCategory = sceneInfo.categoryCount - 1;
@@ -1195,7 +1196,7 @@ void RenderDevice::ProcessEvent(MSG Msg)
                 case VK_F2:
                     if (engine.devMenu) {
                         sceneInfo.listPos++;
-                        if (sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd) {
+                        if (sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd || sceneInfo.listPos == 0) {
                             sceneInfo.activeCategory++;
                             if (sceneInfo.activeCategory >= sceneInfo.categoryCount) {
                                 sceneInfo.activeCategory = 0;

--- a/RSDKv5/RSDK/Graphics/GLFW/GLFWRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/GLFW/GLFWRenderDevice.cpp
@@ -1067,7 +1067,8 @@ void RenderDevice::ProcessKeyEvent(GLFWwindow *, int32 key, int32 scancode, int3
                 case GLFW_KEY_F1:
                     if (engine.devMenu) {
                         sceneInfo.listPos--;
-                        if (sceneInfo.listPos < sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetStart) {
+                        if (sceneInfo.listPos < sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetStart
+                            || sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd) {
                             sceneInfo.activeCategory--;
                             if (sceneInfo.activeCategory >= sceneInfo.categoryCount) {
                                 sceneInfo.activeCategory = sceneInfo.categoryCount - 1;
@@ -1091,7 +1092,7 @@ void RenderDevice::ProcessKeyEvent(GLFWwindow *, int32 key, int32 scancode, int3
                 case GLFW_KEY_F2:
                     if (engine.devMenu) {
                         sceneInfo.listPos++;
-                        if (sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd) {
+                        if (sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd || sceneInfo.listPos == 0) {
                             sceneInfo.activeCategory++;
                             if (sceneInfo.activeCategory >= sceneInfo.categoryCount) {
                                 sceneInfo.activeCategory = 0;

--- a/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
@@ -856,7 +856,8 @@ void RenderDevice::ProcessEvent(SDL_Event event)
                 case SDL_SCANCODE_F1:
                     if (engine.devMenu) {
                         sceneInfo.listPos--;
-                        if (sceneInfo.listPos < sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetStart) {
+                        if (sceneInfo.listPos < sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetStart
+                            || sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd) {
                             sceneInfo.activeCategory--;
                             if (sceneInfo.activeCategory >= sceneInfo.categoryCount) {
                                 sceneInfo.activeCategory = sceneInfo.categoryCount - 1;
@@ -880,7 +881,7 @@ void RenderDevice::ProcessEvent(SDL_Event event)
                 case SDL_SCANCODE_F2:
                     if (engine.devMenu) {
                         sceneInfo.listPos++;
-                        if (sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd) {
+                        if (sceneInfo.listPos >= sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd || sceneInfo.listPos == 0) {
                             sceneInfo.activeCategory++;
                             if (sceneInfo.activeCategory >= sceneInfo.categoryCount) {
                                 sceneInfo.activeCategory = 0;

--- a/RSDKv5U/RSDKv5U_vk.vcxproj
+++ b/RSDKv5U/RSDKv5U_vk.vcxproj
@@ -457,7 +457,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
-    <ProjectGuid>{A842E0D8-1D55-4B5D-92B2-5B6770021626}</ProjectGuid>
+    <ProjectGuid>{268BB4CA-8A19-11ED-A1EB-0242AC120002}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>SonicMania</RootNamespace>
     <ProjectName>RSDKv5U-vk</ProjectName>
@@ -548,12 +548,12 @@
       <AdditionalLibraryDirectories>$(VK_SDK_PATH)/Lib/;$(SolutionDir)dependencies/windows/libtheora/win32/VS2010/$(Platform)/$(Configuration)/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/$(Configuration)/;$(SolutionDir)dependencies/ogl/glfw/lib/;$(SolutionDir)dependencies/ogl/glfw/lib-vc2022/;$(SolutionDir)dependencies/ogl/glew/lib/Release/$(Platform)/;</AdditionalLibraryDirectories>
       <AdditionalDependencies>vulkan-1.lib;libogg.lib;libtheora_static.lib;winmm.lib;comctl32.lib;opengl32.lib;glew32.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-      <PostBuildEvent>
-        <Command>copy /Y "$(SolutionDir)dependencies\ogl\glew\bin\Release\$(Platform)\glew32.dll" "$(OutDir)" </Command>
-      </PostBuildEvent>
-      <PostBuildEvent>
-        <Message>copying GLEW library DLL to the build directory. build should fail if it's not found</Message>
-      </PostBuildEvent>
+    <PostBuildEvent>
+      <Command>copy /Y "$(SolutionDir)dependencies\ogl\glew\bin\Release\$(Platform)\glew32.dll" "$(OutDir)" </Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>copying GLEW library DLL to the build directory. build should fail if it's not found</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -573,12 +573,12 @@
       <AdditionalLibraryDirectories>$(VK_SDK_PATH)/Lib/;$(SolutionDir)dependencies/windows/libtheora/win32/VS2010/$(Platform)/$(Configuration)/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/$(Configuration)/;$(SolutionDir)dependencies/ogl/glfw/lib/;$(SolutionDir)dependencies/ogl/glfw/lib-vc2022/;$(SolutionDir)dependencies/ogl/glew/lib/Release/$(Platform)/;</AdditionalLibraryDirectories>
       <AdditionalDependencies>vulkan-1.lib;libogg.lib;libtheora_static.lib;winmm.lib;comctl32.lib;opengl32.lib;glew32.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-      <PostBuildEvent>
-        <Command>copy /Y "$(SolutionDir)dependencies\ogl\glew\bin\Release\$(Platform)\glew32.dll" "$(OutDir)" </Command>
-      </PostBuildEvent>
-      <PostBuildEvent>
-        <Message>copying GLEW library DLL to the build directory. build should fail if it's not found</Message>
-      </PostBuildEvent>
+    <PostBuildEvent>
+      <Command>copy /Y "$(SolutionDir)dependencies\ogl\glew\bin\Release\$(Platform)\glew32.dll" "$(OutDir)" </Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>copying GLEW library DLL to the build directory. build should fail if it's not found</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -602,12 +602,12 @@
       <AdditionalLibraryDirectories>$(VK_SDK_PATH)/Lib/;$(SolutionDir)dependencies/windows/libtheora/win32/VS2010/$(Platform)/$(Configuration)/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/$(Configuration)/;$(SolutionDir)dependencies/ogl/glfw/lib/;$(SolutionDir)dependencies/ogl/glfw/lib-vc2022/;$(SolutionDir)dependencies/ogl/glew/lib/Release/$(Platform)/;</AdditionalLibraryDirectories>
       <AdditionalDependencies>vulkan-1.lib;libogg.lib;libtheora_static.lib;winmm.lib;comctl32.lib;opengl32.lib;glew32.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-      <PostBuildEvent>
-        <Command>copy /Y "$(SolutionDir)dependencies\ogl\glew\bin\Release\$(Platform)\glew32.dll" "$(OutDir)" </Command>
-      </PostBuildEvent>
-      <PostBuildEvent>
-        <Message>copying GLEW library DLL to the build directory. build should fail if it's not found</Message>
-      </PostBuildEvent>
+    <PostBuildEvent>
+      <Command>copy /Y "$(SolutionDir)dependencies\ogl\glew\bin\Release\$(Platform)\glew32.dll" "$(OutDir)" </Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>copying GLEW library DLL to the build directory. build should fail if it's not found</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -631,12 +631,12 @@
       <AdditionalLibraryDirectories>$(VK_SDK_PATH)/Lib/;$(SolutionDir)dependencies/windows/libtheora/win32/VS2010/$(Platform)/$(Configuration)/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/$(Configuration)/;$(SolutionDir)dependencies/ogl/glfw/lib/;$(SolutionDir)dependencies/ogl/glfw/lib-vc2022/;$(SolutionDir)dependencies/ogl/glew/lib/Release/$(Platform);</AdditionalLibraryDirectories>
       <AdditionalDependencies>vulkan-1.lib;libogg.lib;libtheora_static.lib;winmm.lib;comctl32.lib;opengl32.lib;glew32.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-      <PostBuildEvent>
-        <Command>copy /Y "$(SolutionDir)dependencies\ogl\glew\bin\Release\$(Platform)\glew32.dll" "$(OutDir)" </Command>
-      </PostBuildEvent>
-      <PostBuildEvent>
-        <Message>copying GLEW library DLL to the build directory. build should fail if it's not found</Message>
-      </PostBuildEvent>
+    <PostBuildEvent>
+      <Command>copy /Y "$(SolutionDir)dependencies\ogl\glew\bin\Release\$(Platform)\glew32.dll" "$(OutDir)" </Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>copying GLEW library DLL to the build directory. build should fail if it's not found</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
When using the F1 dev function to switch to the previous scene while on the first scene of the first category ("Presentation - Logos" in Mania Plus), instead of taking you to the last scene in the last category ("Videos - True End?" in this case) as expected, it tries to load a nonexistent scene in the Presentation category, which results in a crash:
![image](https://user-images.githubusercontent.com/7158344/218823758-5f37c544-b3ea-427f-b0bd-a95cf0f6e438.png)

This happens because the function doesn't check for if ``sceneInfo.listPos`` underflows after it decreases by 1, which is fixed in this pull request. Although you realistically are never going to have 256 categories consisting of 256 scenes each, I also added a check for if listPos overflows when using the F2 function.