### PR TITLE
Add preprocessor checks for GCC pragmas

### DIFF
--- a/RSDKv5/RSDK/Audio/XAudio/XAudioDevice.hpp
+++ b/RSDKv5/RSDK/Audio/XAudio/XAudioDevice.hpp
@@ -15,9 +15,11 @@ class AudioDeviceCallback : public IXAudio2VoiceCallback
     void WINAPI OnVoiceError(void *pBufferContext, HRESULT Error) {}
 };
 
+#ifdef __GNUC__
 // using clang to compile? stfu
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmicrosoft-exception-spec"
+#endif
 
 class AudioEngineCallback : public IXAudio2EngineCallback
 {
@@ -26,7 +28,9 @@ class AudioEngineCallback : public IXAudio2EngineCallback
     void WINAPI OnCriticalError(HRESULT Error);
 };
 
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 struct AudioDevice : public AudioDeviceBase {
     static bool32 Init();


### PR DESCRIPTION
This fixes the warnings and errors from building with the Visual Studio solution method introduced in [481464a](https://github.com/Rubberduckycooly/RSDKv5-Decompilation/commit/7718f7c6864ce19b73937d7aced6a4be76f344a1).