### PR TITLE
Fixed PortAudio linking error in Linux Makefile

### DIFF
--- a/makefiles/Linux.cfg
+++ b/makefiles/Linux.cfg
@@ -30,6 +30,6 @@ ifeq ($(SUBSYSTEM),SDL2)
     RSDK_LIBS += `$(PKGCONFIG) --libs --static sdl2`
 endif
 
-RSDK_CFLAGS += `$(PKGCONFIG) --cflags --static theora theoradec zlib`
-RSDK_LIBS += `$(PKGCONFIG) --libs --static theora theoradec zlib`
+RSDK_CFLAGS += `$(PKGCONFIG) --cflags --static theora theoradec zlib portaudio`
+RSDK_LIBS += `$(PKGCONFIG) --libs --static theora theoradec zlib portaudio`
 


### PR DESCRIPTION
The issue was the failure to build due to PortAudio not being linked at all.