### PR TITLE
call glfwSwapInterval in SetupRendering to enable/disable vsync

### DIFF
--- a/RSDKv5/RSDK/Graphics/GLFW/GLFWRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/GLFW/GLFWRenderDevice.cpp
@@ -114,6 +114,8 @@ bool RenderDevice::SetupRendering()
         return false;
     }
 
+    glfwSwapInterval(videoSettings.vsync ? 1 : 0);
+
     GetDisplays();
 
     if (!InitGraphicsAPI() || !InitShaders())


### PR DESCRIPTION
Currently, the GLFW backend doesn't take into account if vsync is enabled or not, and makes no calls to `glfwSwapInterval`.