### PR TITLE
Add dev menu/title screen/reload button commands in legacy script error screens

### DIFF
--- a/RSDKv5/RSDK/Core/Legacy/v3/RetroEnginev3.cpp
+++ b/RSDKv5/RSDK/Core/Legacy/v3/RetroEnginev3.cpp
@@ -209,6 +209,26 @@ void RSDK::Legacy::v3::ProcessEngine()
 
             int32 yOff = DevOutput_GetStringYSize(scriptErrorMessage);
             DrawDevString(scriptErrorMessage, 8, currentScreen->center.y - (yOff >> 1) + 8, 0, 0xF0F0F0);
+
+            ProcessInput();
+            if (controller[CONT_ANY].keyStart.press || controller[CONT_ANY].keyA.press) {
+                OpenDevMenu();
+            }
+            else if (controller[CONT_ANY].keyB.press) {
+                ResetCurrentStageFolder();
+                sceneInfo.activeCategory = 0;
+                gameMode                 = ENGINE_MAINGAME;
+                stageMode                = STAGEMODE_LOAD;
+                sceneInfo.listPos        = 0;
+            }
+            else if (controller[CONT_ANY].keyC.press) {
+                ResetCurrentStageFolder();
+#if RETRO_USE_MOD_LOADER
+                RefreshModFolders();
+#endif
+                gameMode  = ENGINE_MAINGAME;
+                stageMode = STAGEMODE_LOAD;
+            }
             break;
         }
 

--- a/RSDKv5/RSDK/Core/Legacy/v4/RetroEnginev4.cpp
+++ b/RSDKv5/RSDK/Core/Legacy/v4/RetroEnginev4.cpp
@@ -267,6 +267,26 @@ void RSDK::Legacy::v4::ProcessEngine()
 
             int32 yOff = DevOutput_GetStringYSize(scriptErrorMessage);
             DrawDevString(scriptErrorMessage, 8, currentScreen->center.y - (yOff >> 1) + 8, 0, 0xF0F0F0);
+
+            ProcessInput();
+            if (controller[CONT_ANY].keyStart.press || controller[CONT_ANY].keyA.press) {
+                OpenDevMenu();
+            }
+            else if (controller[CONT_ANY].keyB.press) {
+                ResetCurrentStageFolder();
+                sceneInfo.activeCategory = 0;
+                gameMode                 = ENGINE_MAINGAME;
+                stageMode                = STAGEMODE_LOAD;
+                sceneInfo.listPos        = 0;
+            }
+            else if (controller[CONT_ANY].keyC.press) {
+                ResetCurrentStageFolder();
+#if RETRO_USE_MOD_LOADER
+                RefreshModFolders();
+#endif
+                gameMode  = ENGINE_MAINGAME;
+                stageMode = STAGEMODE_LOAD;
+            }
             break;
         }
 


### PR DESCRIPTION
These were missing from v5U compared to the standalone decomps.