### PR TITLE
ModAPI: Fix some more memory leaks

### DIFF
--- a/RSDKv5/RSDK/Core/ModAPI.cpp
+++ b/RSDKv5/RSDK/Core/ModAPI.cpp
@@ -613,6 +613,7 @@ void loadCfg(ModInfo *info, std::string path)
                 }
                 else
                     info->config[catBuf][keyBuf] = std::to_string(ReadInt32(&cfg, false));
+                delete[] keyBuf;
             }
         }
 
@@ -654,24 +655,24 @@ bool32 RSDK::LoadMod(ModInfo *info, std::string modsPath, std::string folder, bo
         DrawStatus("Parsing INI...");
 
         fClose(f);
-        auto ini = iniparser_load((modDir + "/mod.ini").c_str());
+        auto modIni = iniparser_load((modDir + "/mod.ini").c_str());
 
         info->path       = modDir;
         info->folderName = folder;
-        info->id         = iniparser_getstring(ini, ":ModID", folder.c_str());
+        info->id         = iniparser_getstring(modIni, ":ModID", folder.c_str());
         info->active     = active;
 
-        info->name    = iniparser_getstring(ini, ":Name", "Unnamed Mod");
-        info->desc    = iniparser_getstring(ini, ":Description", "");
-        info->author  = iniparser_getstring(ini, ":Author", "Unknown Author");
-        info->version = iniparser_getstring(ini, ":Version", "1.0.0");
+        info->name    = iniparser_getstring(modIni, ":Name", "Unnamed Mod");
+        info->desc    = iniparser_getstring(modIni, ":Description", "");
+        info->author  = iniparser_getstring(modIni, ":Author", "Unknown Author");
+        info->version = iniparser_getstring(modIni, ":Version", "1.0.0");
 
-        info->redirectSaveRAM  = iniparser_getboolean(ini, ":RedirectSaveRAM", false);
-        info->disableGameLogic = iniparser_getboolean(ini, ":DisableGameLogic", false);
+        info->redirectSaveRAM  = iniparser_getboolean(modIni, ":RedirectSaveRAM", false);
+        info->disableGameLogic = iniparser_getboolean(modIni, ":DisableGameLogic", false);
 
-        info->forceVersion = iniparser_getint(ini, ":ForceVersion", 0);
+        info->forceVersion = iniparser_getint(modIni, ":ForceVersion", 0);
         if (!info->forceVersion) {
-            info->targetVersion = iniparser_getint(ini, ":TargetVersion", 5);
+            info->targetVersion = iniparser_getint(modIni, ":TargetVersion", 5);
             if (info->targetVersion != -1 && ENGINE_VERSION) {
                 if (info->targetVersion < 3 || info->targetVersion > 5) {
                     PrintLog(PRINT_NORMAL, "[MOD] Invalid target version. Should be 3, 4, or 5");
@@ -685,10 +686,12 @@ bool32 RSDK::LoadMod(ModInfo *info, std::string modsPath, std::string folder, bo
         }
         else
             info->targetVersion = info->forceVersion;
-        info->forceScripts = iniparser_getboolean(ini, ":TxtScripts", false);
+        info->forceScripts = iniparser_getboolean(modIni, ":TxtScripts", false);
 
-        if (!active)
+        if (!active) {
+            iniparser_freedict(modIni);
             return true;
+        }
 
         // ASSETS
         DrawStatus("Scanning mod folder...");
@@ -696,7 +699,7 @@ bool32 RSDK::LoadMod(ModInfo *info, std::string modsPath, std::string folder, bo
 
         if (!getVersion) {
             // LOGIC
-            std::string logic(iniparser_getstring(ini, ":LogicFile", ""));
+            std::string logic(iniparser_getstring(modIni, ":LogicFile", ""));
             if (logic.length()) {
                 std::istringstream stream(logic);
                 std::string buf;
@@ -715,7 +718,7 @@ bool32 RSDK::LoadMod(ModInfo *info, std::string modsPath, std::string folder, bo
                             // PrintLog(PRINT_NORMAL, "[MOD] Failed to load mod %s...", folder.c_str());
                             PrintLog(PRINT_NORMAL, "[MOD] ERROR: Failed to find modInfo", file.string().c_str());
 
-                            iniparser_freedict(ini);
+                            iniparser_freedict(modIni);
                             currentMod = cur;
                             return false;
                         }
@@ -725,7 +728,7 @@ bool32 RSDK::LoadMod(ModInfo *info, std::string modsPath, std::string folder, bo
                             PrintLog(PRINT_NORMAL, "[MOD] ERROR: Logic file '%s' engineVer %d does not match expected engineVer of %d",
                                      file.string().c_str(), modInfo->engineVer, targetModVersion.engineVer);
 
-                            iniparser_freedict(ini);
+                            iniparser_freedict(modIni);
                             currentMod = cur;
                             return false;
                         }
@@ -754,7 +757,7 @@ bool32 RSDK::LoadMod(ModInfo *info, std::string modsPath, std::string folder, bo
                         // PrintLog(PRINT_NORMAL, "[MOD] Failed to load mod %s...", folder.c_str());
                         PrintLog(PRINT_NORMAL, "[MOD] ERROR: Failed to link logic '%s'", file.string().c_str());
 
-                        iniparser_freedict(ini);
+                        iniparser_freedict(modIni);
                         currentMod = cur;
                         return false;
                     }
@@ -768,32 +771,33 @@ bool32 RSDK::LoadMod(ModInfo *info, std::string modsPath, std::string folder, bo
 
                 fClose(set);
                 using namespace std;
-                auto ini  = iniparser_load((modDir + "/modSettings.ini").c_str());
-                int32 sec = iniparser_getnsec(ini);
+                auto modSettingsIni  = iniparser_load((modDir + "/modSettings.ini").c_str());
+                int32 sec = iniparser_getnsec(modSettingsIni);
                 if (sec) {
                     for (int32 i = 0; i < sec; ++i) {
-                        const char *secn  = iniparser_getsecname(ini, i);
-                        int32 len         = iniparser_getsecnkeys(ini, secn);
+                        const char *secn  = iniparser_getsecname(modSettingsIni, i);
+                        int32 len         = iniparser_getsecnkeys(modSettingsIni, secn);
                         const char **keys = new const char *[len];
-                        iniparser_getseckeys(ini, secn, keys);
+                        iniparser_getseckeys(modSettingsIni, secn, keys);
                         map<string, string> secset;
                         for (int32 j = 0; j < len; ++j)
-                            secset.insert(pair<string, string>(keys[j] + strlen(secn) + 1, iniparser_getstring(ini, keys[j], "")));
+                            secset.insert(pair<string, string>(keys[j] + strlen(secn) + 1, iniparser_getstring(modSettingsIni, keys[j], "")));
                         info->settings.insert(pair<string, map<string, string>>(secn, secset));
+                        delete[] keys;
                     }
                 }
                 else {
                     // either you use categories or you don't, i don't make the rules
                     map<string, string> secset;
-                    for (int32 j = 0; j < ini->n; ++j) secset.insert(pair<string, string>(ini->key[j] + 1, ini->val[j]));
+                    for (int32 j = 0; j < modSettingsIni->n; ++j) secset.insert(pair<string, string>(modSettingsIni->key[j] + 1, modSettingsIni->val[j]));
                     info->settings.insert(pair<string, map<string, string>>("", secset));
                 }
-                iniparser_freedict(ini);
+                iniparser_freedict(modSettingsIni);
             }
             // CONFIG
             loadCfg(info, modDir + "/modConfig.cfg");
 
-            std::string cfg(iniparser_getstring(ini, ":ConfigFile", ""));
+            std::string cfg(iniparser_getstring(modIni, ":ConfigFile", ""));
             bool saveCfg = false;
             if (cfg.length() && info->active) {
                 std::istringstream stream(cfg);
@@ -834,17 +838,18 @@ bool32 RSDK::LoadMod(ModInfo *info, std::string modsPath, std::string folder, bo
                             saveCfg = true;
                             fClose(set);
                             using namespace std;
-                            auto ini  = iniparser_load(file.string().c_str());
-                            int32 sec = iniparser_getnsec(ini);
+                            auto cfgIni  = iniparser_load(file.string().c_str());
+                            int32 sec = iniparser_getnsec(cfgIni);
                             for (int32 i = 0; i < sec; ++i) {
-                                const char *secn  = iniparser_getsecname(ini, i);
-                                int32 len         = iniparser_getsecnkeys(ini, secn);
+                                const char *secn  = iniparser_getsecname(cfgIni, i);
+                                int32 len         = iniparser_getsecnkeys(cfgIni, secn);
                                 const char **keys = new const char *[len];
-                                iniparser_getseckeys(ini, secn, keys);
+                                iniparser_getseckeys(cfgIni, secn, keys);
                                 for (int32 j = 0; j < len; ++j)
-                                    info->config[secn][keys[j] + strlen(secn) + 1] = iniparser_getstring(ini, keys[j], "");
+                                    info->config[secn][keys[j] + strlen(secn) + 1] = iniparser_getstring(cfgIni, keys[j], "");
+                                delete[] keys;
                             }
-                            iniparser_freedict(ini);
+                            iniparser_freedict(cfgIni);
                         }
                     }
                     else if (mode == 2)
@@ -890,7 +895,7 @@ bool32 RSDK::LoadMod(ModInfo *info, std::string modsPath, std::string folder, bo
             }
         }
 
-        iniparser_freedict(ini);
+        iniparser_freedict(modIni);
         currentMod = cur;
         return true;
     }
@@ -1529,6 +1534,7 @@ void RSDK::SetSettingsString(const char *key, String *val)
     char *buf = new char[val->length];
     GetCString(buf, val);
     SetModSettingsValue(key, buf);
+    delete[] buf;
 }
 
 void RSDK::SaveSettings()

--- a/RSDKv5/RSDK/Core/RetroEngine.cpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.cpp
@@ -737,7 +737,14 @@ void RSDK::InitEngine()
 
 void RSDK::StartGameObjects()
 {
+#if RETRO_USE_MOD_LOADER
+    // ObjectClass is a non-POD struct because of std::function, we can't memset(0) or it would overwrite vtable data
+    for (int i = 0; i < OBJECT_COUNT; ++i) {
+        objectClassList[i] = {};
+    }
+#else
     memset(&objectClassList, 0, sizeof(objectClassList));
+#endif
 
     sceneInfo.classCount     = 0;
     sceneInfo.activeCategory = 0;


### PR DESCRIPTION
Free the main mod.ini dictionary whenever the mod isn't active. Rename most ini dictionaries to use different variable names, which makes this part of the code less confusing (each of them were using `ini`).

Free some temporary char buffers.

Whenever the mod loader is enabled, void* are replaced with std::function
in the ObjectClass struct, which makes this a non-POD struct.
Using memset on it corrupts the vtables, which leads to memory leaks later on.
Manually zero-initialize this list instead when the mod loader is enabled.