### PR TITLE
Parity changes between standalone v3/v4 decomps and v5U

### DIFF
--- a/RSDKv5/RSDK/Core/Legacy/v3/RetroEnginev3.cpp
+++ b/RSDKv5/RSDK/Core/Legacy/v3/RetroEnginev3.cpp
@@ -164,9 +164,16 @@ bool32 RSDK::Legacy::v3::LoadGameConfig(const char *filepath)
         CloseFile(&info);
 
         sceneInfo.listPos = startScene;
+
 #if RETRO_USE_MOD_LOADER
         v3::LoadGameXML();
-        SetGlobalVariableByName("options.devMenuFlag", engine.devMenu ? 1 : 0);
+        SetGlobalVariableByName("Options.DevMenuFlag", engine.devMenu ? 1 : 0);
+        SetGlobalVariableByName("Engine.Standalone", 0);
+#if !RSDK_AUTOBUILD
+        SetGlobalVariableByName("game.hasPlusDLC", 1);
+#else
+        SetGlobalVariableByName("game.hasPlusDLC", 0);
+#endif
 #endif
 
         SetGlobalVariableByName("Engine.PlatformId", gamePlatformID);
@@ -268,40 +275,44 @@ enum RetroEngineCallbacks {
     CALLBACK_AGEGATE                 = 100,
 
     // Sonic Origins Notify Callbacks
-    NOTIFY_DEATH_EVENT        = 128,
-    NOTIFY_TOUCH_SIGNPOST     = 129,
-    NOTIFY_HUD_ENABLE         = 130,
-    NOTIFY_ADD_COIN           = 131,
-    NOTIFY_KILL_ENEMY         = 132,
-    NOTIFY_SAVESLOT_SELECT    = 133,
-    NOTIFY_FUTURE_PAST        = 134,
-    NOTIFY_GOTO_FUTURE_PAST   = 135,
-    NOTIFY_BOSS_END           = 136,
-    NOTIFY_SPECIAL_END        = 137,
-    NOTIFY_DEBUGPRINT         = 138,
-    NOTIFY_KILL_BOSS          = 139,
-    NOTIFY_TOUCH_EMERALD      = 140,
-    NOTIFY_STATS_ENEMY        = 141,
-    NOTIFY_STATS_CHARA_ACTION = 142,
-    NOTIFY_STATS_RING         = 143,
-    NOTIFY_STATS_MOVIE        = 144,
-    NOTIFY_STATS_PARAM_1      = 145,
-    NOTIFY_STATS_PARAM_2      = 146,
-    NOTIFY_CHARACTER_SELECT   = 147,
-    NOTIFY_SPECIAL_RETRY      = 148,
-    NOTIFY_TOUCH_CHECKPOINT   = 149,
-    NOTIFY_ACT_FINISH         = 150,
-    NOTIFY_1P_VS_SELECT       = 151,
-    NOTIFY_CONTROLLER_SUPPORT = 152,
-    NOTIFY_STAGE_RETRY        = 153,
-    NOTIFY_SOUND_TRACK        = 154,
-    NOTIFY_GOOD_ENDING        = 155,
-    NOTIFY_BACK_TO_MAINMENU   = 156,
-    NOTIFY_LEVEL_SELECT_MENU  = 157,
-    NOTIFY_PLAYER_SET         = 158,
-    NOTIFY_EXTRAS_MODE        = 159,
-    NOTIFY_SPIN_DASH_TYPE     = 160,
-    NOTIFY_TIME_OVER          = 161,
+    NOTIFY_DEATH_EVENT         = 128,
+    NOTIFY_TOUCH_SIGNPOST      = 129,
+    NOTIFY_HUD_ENABLE          = 130,
+    NOTIFY_ADD_COIN            = 131,
+    NOTIFY_KILL_ENEMY          = 132,
+    NOTIFY_SAVESLOT_SELECT     = 133,
+    NOTIFY_FUTURE_PAST         = 134,
+    NOTIFY_GOTO_FUTURE_PAST    = 135,
+    NOTIFY_BOSS_END            = 136,
+    NOTIFY_SPECIAL_END         = 137,
+    NOTIFY_DEBUGPRINT          = 138,
+    NOTIFY_KILL_BOSS           = 139,
+    NOTIFY_TOUCH_EMERALD       = 140,
+    NOTIFY_STATS_ENEMY         = 141,
+    NOTIFY_STATS_CHARA_ACTION  = 142,
+    NOTIFY_STATS_RING          = 143,
+    NOTIFY_STATS_MOVIE         = 144,
+    NOTIFY_STATS_PARAM_1       = 145,
+    NOTIFY_STATS_PARAM_2       = 146,
+    NOTIFY_CHARACTER_SELECT    = 147,
+    NOTIFY_SPECIAL_RETRY       = 148,
+    NOTIFY_TOUCH_CHECKPOINT    = 149,
+    NOTIFY_ACT_FINISH          = 150,
+    NOTIFY_1P_VS_SELECT        = 151,
+    NOTIFY_CONTROLLER_SUPPORT  = 152,
+    NOTIFY_STAGE_RETRY         = 153,
+    NOTIFY_SOUND_TRACK         = 154,
+    NOTIFY_GOOD_ENDING         = 155,
+    NOTIFY_BACK_TO_MAINMENU    = 156,
+    NOTIFY_LEVEL_SELECT_MENU   = 157,
+    NOTIFY_PLAYER_SET          = 158,
+    NOTIFY_EXTRAS_MODE         = 159,
+    NOTIFY_SPIN_DASH_TYPE      = 160,
+    NOTIFY_TIME_OVER           = 161,
+    NOTIFY_TIMEATTACK_MODE     = 162,
+    NOTIFY_STATS_BREAK_OBJECT  = 163,
+    NOTIFY_STATS_SAVE_FUTURE   = 164,
+    NOTIFY_STATS_CHARA_ACTION2 = 165,
 
     // Sega Forever stuff
     CALLBACK_SHOWMENU_2                       = 997,
@@ -309,7 +320,7 @@ enum RetroEngineCallbacks {
     CALLBACK_CHANGEADSTYPE                    = 999,
     CALLBACK_NONE_1000                        = 1000,
     CALLBACK_NONE_1001                        = 1001,
-    CALLBACK_NONE_1002                        = 1002,
+    CALLBACK_NONE_1006                        = 1002,
     CALLBACK_ONSHOWINTERSTITIAL               = 1003,
     CALLBACK_ONSHOWBANNER                     = 1004,
     CALLBACK_ONSHOWBANNER_PAUSESTART          = 1005,
@@ -325,6 +336,9 @@ enum RetroEngineCallbacks {
     CALLBACK_SHOWCOUNTDOWNMENU                = 1015,
     CALLBACK_ONVISIBLEMAINMENU_1              = 1016,
     CALLBACK_ONVISIBLEMAINMENU_0              = 1017,
+    CALLBACK_ONSHOWREWARDADS                  = 1018,
+    CALLBACK_ONSHOWBANNER_2                   = 1019,
+    CALLBACK_ONSHOWINTERSTITIAL_5             = 1020,
 
 #if RETRO_USE_MOD_LOADER
     // Mod CBs start at 0x1000
@@ -337,9 +351,8 @@ void RSDK::Legacy::v3::RetroEngineCallback(int32 callbackID)
 {
     // Sonic Origins Params
     int32 notifyParam1 = GetGlobalVariableByName("game.callbackParam0");
-    // int32 notifyParam2 = GetGlobalVariableByName("game.callbackParam1");
-    // int32 notifyParam3 = GetGlobalVariableByName("game.callbackParam2");
-    // int32 notifyParam4 = GetGlobalVariableByName("game.callbackParam3");
+    int32 notifyParam2 = GetGlobalVariableByName("game.callbackParam1");
+    int32 notifyParam3 = GetGlobalVariableByName("game.callbackParam2");
 
     switch (callbackID) {
         default: PrintLog(PRINT_NORMAL, "Callback: Unknown (%d)", callbackID); break;
@@ -401,7 +414,10 @@ void RSDK::Legacy::v3::RetroEngineCallback(int32 callbackID)
         case NOTIFY_DEATH_EVENT: PrintLog(PRINT_NORMAL, "NOTIFY: DeathEvent() -> %d", notifyParam1); break;
         case NOTIFY_TOUCH_SIGNPOST: PrintLog(PRINT_NORMAL, "NOTIFY: TouchSignPost() -> %d", notifyParam1); break;
         case NOTIFY_HUD_ENABLE: PrintLog(PRINT_NORMAL, "NOTIFY: HUDEnable() -> %d", notifyParam1); break;
-        case NOTIFY_ADD_COIN: PrintLog(PRINT_NORMAL, "NOTIFY: AddCoin() -> %d", notifyParam1); break;
+        case NOTIFY_ADD_COIN:
+            PrintLog(PRINT_NORMAL, "NOTIFY: AddCoin() -> %d", notifyParam1);
+            SetGlobalVariableByName("game.coinCount", GetGlobalVariableByName("game.coinCount") + notifyParam1);
+            break;
         case NOTIFY_KILL_ENEMY: PrintLog(PRINT_NORMAL, "NOTIFY: KillEnemy() -> %d", notifyParam1); break;
         case NOTIFY_SAVESLOT_SELECT: PrintLog(PRINT_NORMAL, "NOTIFY: SaveSlotSelect() -> %d", notifyParam1); break;
         case NOTIFY_FUTURE_PAST:
@@ -411,11 +427,11 @@ void RSDK::Legacy::v3::RetroEngineCallback(int32 callbackID)
         case NOTIFY_GOTO_FUTURE_PAST: PrintLog(PRINT_NORMAL, "NOTIFY: GotoFuturePast() -> %d", notifyParam1); break;
         case NOTIFY_BOSS_END: PrintLog(PRINT_NORMAL, "NOTIFY: BossEnd() -> %d", notifyParam1); break;
         case NOTIFY_SPECIAL_END: PrintLog(PRINT_NORMAL, "NOTIFY: SpecialEnd() -> %d", notifyParam1); break;
-        case NOTIFY_DEBUGPRINT: PrintLog(PRINT_NORMAL, "NOTIFY: DebugPrint() -> %d", notifyParam1); break;
+        case NOTIFY_DEBUGPRINT: PrintLog(PRINT_NORMAL, "NOTIFY: DebugPrint() -> %d, %d, %d", notifyParam1, notifyParam2, notifyParam3); break;
         case NOTIFY_KILL_BOSS: PrintLog(PRINT_NORMAL, "NOTIFY: KillBoss() -> %d", notifyParam1); break;
         case NOTIFY_TOUCH_EMERALD: PrintLog(PRINT_NORMAL, "NOTIFY: TouchEmerald() -> %d", notifyParam1); break;
-        case NOTIFY_STATS_ENEMY: PrintLog(PRINT_NORMAL, "NOTIFY: StatsEnemy() -> %d", notifyParam1); break;
-        case NOTIFY_STATS_CHARA_ACTION: PrintLog(PRINT_NORMAL, "NOTIFY: StatsCharaAction() -> %d", notifyParam1); break;
+        case NOTIFY_STATS_ENEMY: PrintLog(PRINT_NORMAL, "NOTIFY: StatsEnemy() -> %d, %d, %d", notifyParam1, notifyParam2, notifyParam3); break;
+        case NOTIFY_STATS_CHARA_ACTION: PrintLog(PRINT_NORMAL, "NOTIFY: StatsCharaAction() -> %d, %d, %d", notifyParam1, notifyParam2, notifyParam3); break;
         case NOTIFY_STATS_RING: PrintLog(PRINT_NORMAL, "NOTIFY: StatsRing() -> %d", notifyParam1); break;
         case NOTIFY_STATS_MOVIE:
             PrintLog(PRINT_NORMAL, "NOTIFY: StatsMovie() -> %d", notifyParam1);
@@ -424,19 +440,25 @@ void RSDK::Legacy::v3::RetroEngineCallback(int32 callbackID)
             gameMode                 = ENGINE_MAINGAME;
             stageMode                = STAGEMODE_LOAD;
             break;
-        case NOTIFY_STATS_PARAM_1: PrintLog(PRINT_NORMAL, "NOTIFY: StatsParam1() -> %d", notifyParam1); break;
+        case NOTIFY_STATS_PARAM_1: PrintLog(PRINT_NORMAL, "NOTIFY: StatsParam1() -> %d, %d, %d", notifyParam1, notifyParam2, notifyParam3); break;
         case NOTIFY_STATS_PARAM_2: PrintLog(PRINT_NORMAL, "NOTIFY: StatsParam2() -> %d", notifyParam1); break;
         case NOTIFY_CHARACTER_SELECT:
             PrintLog(PRINT_NORMAL, "NOTIFY: CharacterSelect() -> %d", notifyParam1);
             SetGlobalVariableByName("game.callbackResult", 1);
             SetGlobalVariableByName("game.continueFlag", 0);
             break;
-        case NOTIFY_SPECIAL_RETRY: SetGlobalVariableByName("game.callbackResult", 1); break;
+        case NOTIFY_SPECIAL_RETRY:
+            PrintLog(PRINT_NORMAL, "NOTIFY: SpecialRetry() -> %d, %d, %d", notifyParam1, notifyParam2, notifyParam3);
+            SetGlobalVariableByName("game.callbackResult", 1);
+            break;
         case NOTIFY_TOUCH_CHECKPOINT: PrintLog(PRINT_NORMAL, "NOTIFY: TouchCheckpoint() -> %d", notifyParam1); break;
         case NOTIFY_ACT_FINISH: PrintLog(PRINT_NORMAL, "NOTIFY: ActFinish() -> %d", notifyParam1); break;
         case NOTIFY_1P_VS_SELECT: PrintLog(PRINT_NORMAL, "NOTIFY: 1PVSSelect() -> %d", notifyParam1); break;
-        case NOTIFY_CONTROLLER_SUPPORT: PrintLog(PRINT_NORMAL, "NOTIFY: ControllerSupport() -> %d", notifyParam1); break;
-        case NOTIFY_STAGE_RETRY: PrintLog(PRINT_NORMAL, "NOTIFY: StageRetry() -> %d", notifyParam1); break;
+        case NOTIFY_CONTROLLER_SUPPORT:
+            PrintLog(PRINT_NORMAL, "NOTIFY: ControllerSupport() -> %d", notifyParam1);
+            SetGlobalVariableByName("game.callbackResult", 1);
+            break;
+        case NOTIFY_STAGE_RETRY: PrintLog(PRINT_NORMAL, "NOTIFY: StageRetry() -> %d, %d, %d", notifyParam1, notifyParam2, notifyParam3); break;
         case NOTIFY_SOUND_TRACK: PrintLog(PRINT_NORMAL, "NOTIFY: SoundTrack() -> %d", notifyParam1); break;
         case NOTIFY_GOOD_ENDING: PrintLog(PRINT_NORMAL, "NOTIFY: GoodEnding() -> %d", notifyParam1); break;
         case NOTIFY_BACK_TO_MAINMENU: PrintLog(PRINT_NORMAL, "NOTIFY: BackToMainMenu() -> %d", notifyParam1); break;
@@ -445,14 +467,15 @@ void RSDK::Legacy::v3::RetroEngineCallback(int32 callbackID)
         case NOTIFY_EXTRAS_MODE: PrintLog(PRINT_NORMAL, "NOTIFY: ExtrasMode() -> %d", notifyParam1); break;
         case NOTIFY_SPIN_DASH_TYPE: PrintLog(PRINT_NORMAL, "NOTIFY: SpindashType() -> %d", notifyParam1); break;
         case NOTIFY_TIME_OVER: PrintLog(PRINT_NORMAL, "NOTIFY: TimeOver() -> %d", notifyParam1); break;
+        case NOTIFY_TIMEATTACK_MODE: PrintLog(PRINT_NORMAL, "NOTIFY: TimeAttackMode() -> %d", notifyParam1); break;
+        case NOTIFY_STATS_BREAK_OBJECT: PrintLog(PRINT_NORMAL, "NOTIFY: StatsBreakObject() -> %d, %d", notifyParam1, notifyParam2); break;
+        case NOTIFY_STATS_SAVE_FUTURE: PrintLog(PRINT_NORMAL, "NOTIFY: StatsSaveFuture() -> %d", notifyParam1); break;
+        case NOTIFY_STATS_CHARA_ACTION2: PrintLog(PRINT_NORMAL, "NOTIFY: StatsCharaAction2() -> %d, %d, %d", notifyParam1, notifyParam2, notifyParam3); break;
 
         // Sega Forever stuff
         case CALLBACK_SHOWMENU_2: PrintLog(PRINT_NORMAL, "Callback: showMenu(2)"); break;
         case CALLBACK_SHOWHELPCENTER: PrintLog(PRINT_NORMAL, "Callback: Show Help Center"); break;
         case CALLBACK_CHANGEADSTYPE: PrintLog(PRINT_NORMAL, "Callback: Change Ads Type"); break;
-        case CALLBACK_NONE_1000:
-        case CALLBACK_NONE_1001:
-        case CALLBACK_NONE_1002: PrintLog(PRINT_NORMAL, "Callback: Unknown - %d", callbackID); break;
         case CALLBACK_ONSHOWINTERSTITIAL: PrintLog(PRINT_NORMAL, "Callback: onShowInterstitial(2, 0) - Pause_Duration"); break;
         case CALLBACK_ONSHOWBANNER: PrintLog(PRINT_NORMAL, "Callback: onShowBanner()"); break;
         case CALLBACK_ONSHOWBANNER_PAUSESTART: PrintLog(PRINT_NORMAL, "Callback: onShowBanner() - Pause_Start"); break;
@@ -460,16 +483,22 @@ void RSDK::Legacy::v3::RetroEngineCallback(int32 callbackID)
         case CALLBACK_REMOVEADSBUTTON_FADEOUT: PrintLog(PRINT_NORMAL, "Callback: RemoveAdsButton_FadeOut()"); break;
         case CALLBACK_REMOVEADSBUTTON_FADEIN: PrintLog(PRINT_NORMAL, "Callback: RemoveAdsButton_FadeIn()"); break;
         case CALLBACK_ONSHOWINTERSTITIAL_2:
-        case CALLBACK_ONSHOWINTERSTITIAL_3: PrintLog(PRINT_NORMAL, "Callback: onShowInterstitial(0, 0)"); break;
+        case CALLBACK_ONSHOWINTERSTITIAL_3:
+        case CALLBACK_ONSHOWINTERSTITIAL_5: PrintLog(PRINT_NORMAL, "Callback: onShowInterstitial(0, 0)"); break;
         case CALLBACK_ONSHOWINTERSTITIAL_4: PrintLog(PRINT_NORMAL, "Callback: onShowInterstitial(1, 0)"); break;
         case CALLBACK_ONVISIBLEGRIDBTN_1: PrintLog(PRINT_NORMAL, "Callback: onVisibleGridBtn(1)"); break;
         case CALLBACK_ONVISIBLEGRIDBTN_0: PrintLog(PRINT_NORMAL, "Callback: onVisibleGridBtn(0)"); break;
         case CALLBACK_ONSHOWINTERSTITIAL_PAUSEDURATION: PrintLog(PRINT_NORMAL, "Callback: onShowInterstitial(0, 0) - Pause_Duration"); break;
         case CALLBACK_SHOWCOUNTDOWNMENU: PrintLog(PRINT_NORMAL, "Callback: showCountDownMenu(0)"); break;
         case CALLBACK_ONVISIBLEMAINMENU_1: PrintLog(PRINT_NORMAL, "Callback: onVisibleMainMenu(1)"); break;
-        case CALLBACK_ONVISIBLEMAINMENU_0:
-            PrintLog(PRINT_NORMAL, "Callback: OnVisibleMainMenu(0)");
+        case CALLBACK_ONVISIBLEMAINMENU_0: PrintLog(PRINT_NORMAL, "Callback: OnVisibleMainMenu(0)"); break;
+        case CALLBACK_ONSHOWREWARDADS:
+            PrintLog(PRINT_NORMAL, "Callback: onShowRewardAds(0)");
+
+            // small hack to prevent a softlock
+            SetGlobalVariableByName("RewardAdCallback", 1);
             break;
+        case CALLBACK_ONSHOWBANNER_2: PrintLog(PRINT_NORMAL, "Callback: onShowBanner(4, 0)"); break;
 
             // Mod loader Only
 #if RETRO_USE_MOD_LOADER
@@ -504,6 +533,7 @@ void RSDK::Legacy::v3::LoadGameXML(bool pal)
                 if (pal)
                     LoadXMLPalettes(gameElement);
                 else {
+                    LoadXMLWindowText(gameElement);
                     LoadXMLVariables(gameElement);
                     LoadXMLObjects(gameElement);
                     LoadXMLSoundFX(gameElement);
@@ -520,6 +550,16 @@ void RSDK::Legacy::v3::LoadGameXML(bool pal)
         }
     }
     SetActiveMod(-1);
+}
+
+void RSDK::Legacy::v3::LoadXMLWindowText(const tinyxml2::XMLElement *gameElement)
+{
+    const tinyxml2::XMLElement *titleElement = gameElement->FirstChildElement("title");
+    if (titleElement) {
+        const tinyxml2::XMLAttribute *nameAttr = titleElement->FindAttribute("name");
+        if (nameAttr)
+            StrCopy(gameVerInfo.gameTitle, nameAttr->Value());
+    }
 }
 
 void RSDK::Legacy::v3::LoadXMLVariables(const tinyxml2::XMLElement *gameElement)

--- a/RSDKv5/RSDK/Core/Legacy/v3/RetroEnginev3.hpp
+++ b/RSDKv5/RSDK/Core/Legacy/v3/RetroEnginev3.hpp
@@ -21,6 +21,7 @@ void RetroEngineCallback(int32 callbackID);
 
 #if RETRO_USE_MOD_LOADER
 void LoadGameXML(bool pal = false);
+void LoadXMLWindowText(const tinyxml2::XMLElement *gameElement);
 void LoadXMLVariables(const tinyxml2::XMLElement* gameElement);
 void LoadXMLPalettes(const tinyxml2::XMLElement* gameElement);
 void LoadXMLObjects(const tinyxml2::XMLElement* gameElement);

--- a/RSDKv5/RSDK/Core/Legacy/v4/RetroEnginev4.cpp
+++ b/RSDKv5/RSDK/Core/Legacy/v4/RetroEnginev4.cpp
@@ -168,9 +168,17 @@ bool32 RSDK::Legacy::v4::LoadGameConfig(const char *filepath)
         CloseFile(&info);
 
         sceneInfo.listPos = startScene;
+
 #if RETRO_USE_MOD_LOADER
         v4::LoadGameXML();
         SetGlobalVariableByName("options.devMenuFlag", engine.devMenu ? 1 : 0);
+        SetGlobalVariableByName("engine.standalone", 0);
+#endif
+
+#if !RSDK_AUTOBUILD
+        SetGlobalVariableByName("game.hasPlusDLC", 1);
+#else
+        SetGlobalVariableByName("game.hasPlusDLC", 0);
 #endif
 
         usingBytecode = false;
@@ -330,6 +338,7 @@ void RSDK::Legacy::v4::LoadGameXML(bool pal)
                 if (pal)
                     LoadXMLPalettes(gameElement);
                 else {
+                    LoadXMLWindowText(gameElement);
                     LoadXMLVariables(gameElement);
                     LoadXMLObjects(gameElement);
                     LoadXMLSoundFX(gameElement);
@@ -347,12 +356,23 @@ void RSDK::Legacy::v4::LoadGameXML(bool pal)
     }
     SetActiveMod(-1);
 }
+
+void RSDK::Legacy::v4::LoadXMLWindowText(const tinyxml2::XMLElement *gameElement)
+{
+    const tinyxml2::XMLElement *titleElement = gameElement->FirstChildElement("title");
+    if (titleElement) {
+        const tinyxml2::XMLAttribute *nameAttr = titleElement->FindAttribute("name");
+        if (nameAttr)
+            StrCopy(gameVerInfo.gameTitle, nameAttr->Value());
+    }
+}
+
 void RSDK::Legacy::v4::LoadXMLVariables(const tinyxml2::XMLElement *gameElement)
 {
     const tinyxml2::XMLElement *variablesElement = gameElement->FirstChildElement("variables");
     if (variablesElement) {
         for (const tinyxml2::XMLElement *varElement = variablesElement->FirstChildElement("variable"); varElement;
-             varElement                             = varElement->NextSiblingElement("variable")) {
+            varElement                             = varElement->NextSiblingElement("variable")) {
             const tinyxml2::XMLAttribute *nameAttr = varElement->FindAttribute("name");
             const char *varName                    = "unknownVariable";
             if (nameAttr)
@@ -375,7 +395,7 @@ void RSDK::Legacy::v4::LoadXMLPalettes(const tinyxml2::XMLElement *gameElement)
     const tinyxml2::XMLElement *paletteElement = gameElement->FirstChildElement("palette");
     if (paletteElement) {
         for (const tinyxml2::XMLElement *clrElement = paletteElement->FirstChildElement("color"); clrElement;
-             clrElement                             = clrElement->NextSiblingElement("color")) {
+            clrElement                             = clrElement->NextSiblingElement("color")) {
             const tinyxml2::XMLAttribute *bankAttr = clrElement->FindAttribute("bank");
             int32 clrBank                          = 0;
             if (bankAttr)
@@ -405,7 +425,7 @@ void RSDK::Legacy::v4::LoadXMLPalettes(const tinyxml2::XMLElement *gameElement)
         }
 
         for (const tinyxml2::XMLElement *clrsElement = paletteElement->FirstChildElement("colors"); clrsElement;
-             clrsElement                             = clrsElement->NextSiblingElement("colors")) {
+            clrsElement                             = clrsElement->NextSiblingElement("colors")) {
             const tinyxml2::XMLAttribute *bankAttr = clrsElement->FindAttribute("bank");
             int32 bank                             = 0;
             if (bankAttr)
@@ -453,7 +473,7 @@ void RSDK::Legacy::v4::LoadXMLObjects(const tinyxml2::XMLElement *gameElement)
     const tinyxml2::XMLElement *objectsElement = gameElement->FirstChildElement("objects");
     if (objectsElement) {
         for (const tinyxml2::XMLElement *objElement = objectsElement->FirstChildElement("object"); objElement;
-             objElement                             = objElement->NextSiblingElement("object")) {
+            objElement                             = objElement->NextSiblingElement("object")) {
             const tinyxml2::XMLAttribute *nameAttr = objElement->FindAttribute("name");
             const char *objName                    = "unknownObject";
             if (nameAttr)
@@ -488,7 +508,7 @@ void RSDK::Legacy::v4::LoadXMLSoundFX(const tinyxml2::XMLElement *gameElement)
     const tinyxml2::XMLElement *soundsElement = gameElement->FirstChildElement("sounds");
     if (soundsElement) {
         for (const tinyxml2::XMLElement *sfxElement = soundsElement->FirstChildElement("soundfx"); sfxElement;
-             sfxElement                             = sfxElement->NextSiblingElement("soundfx")) {
+            sfxElement                             = sfxElement->NextSiblingElement("soundfx")) {
             const tinyxml2::XMLAttribute *nameAttr = sfxElement->FindAttribute("name");
             const char *sfxName                    = "unknownSFX";
             if (nameAttr)
@@ -512,7 +532,7 @@ void RSDK::Legacy::v4::LoadXMLPlayers(const tinyxml2::XMLElement *gameElement)
     const tinyxml2::XMLElement *playersElement = gameElement->FirstChildElement("players");
     if (playersElement) {
         for (const tinyxml2::XMLElement *plrElement = playersElement->FirstChildElement("player"); plrElement;
-             plrElement                             = plrElement->NextSiblingElement("player")) {
+            plrElement                             = plrElement->NextSiblingElement("player")) {
             const tinyxml2::XMLAttribute *nameAttr = plrElement->FindAttribute("name");
             const char *plrName                    = "unknownPlayer";
             if (nameAttr)
@@ -532,7 +552,7 @@ void RSDK::Legacy::v4::LoadXMLStages(const tinyxml2::XMLElement *gameElement)
         SceneListInfo *list                     = &sceneInfo.listCategory[l];
         if (listElement) {
             for (const tinyxml2::XMLElement *stgElement = listElement->FirstChildElement("stage"); stgElement;
-                 stgElement                             = stgElement->NextSiblingElement("stage")) {
+                stgElement                             = stgElement->NextSiblingElement("stage")) {
                 const tinyxml2::XMLAttribute *nameAttr = stgElement->FindAttribute("name");
                 const char *stgName                    = "unknownStage";
                 if (nameAttr)

--- a/RSDKv5/RSDK/Core/Legacy/v4/RetroEnginev4.hpp
+++ b/RSDKv5/RSDK/Core/Legacy/v4/RetroEnginev4.hpp
@@ -16,7 +16,8 @@ void ProcessEngine();
 
 #if RETRO_USE_MOD_LOADER
 void LoadGameXML(bool pal = false);
-void LoadXMLVariables(const tinyxml2::XMLElement* gameElement);
+void LoadXMLWindowText(const tinyxml2::XMLElement *gameElement);
+void LoadXMLVariables(const tinyxml2::XMLElement *gameElement);
 void LoadXMLPalettes(const tinyxml2::XMLElement* gameElement);
 void LoadXMLObjects(const tinyxml2::XMLElement* gameElement);
 void LoadXMLSoundFX(const tinyxml2::XMLElement* gameElement);

--- a/RSDKv5/RSDK/Core/RetroEngine.cpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.cpp
@@ -809,7 +809,7 @@ void RSDK::LoadXMLWindowText(const tinyxml2::XMLElement *gameElement)
     if (titleElement) {
         const tinyxml2::XMLAttribute *nameAttr = titleElement->FindAttribute("name");
         if (nameAttr)
-            StrCopy(gameVerInfo.gameTitle, nameAttr->Value());
+            strcpy(gameVerInfo.gameTitle, nameAttr->Value());
     }
 }
 

--- a/RSDKv5/RSDK/Core/RetroEngine.cpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.cpp
@@ -762,7 +762,6 @@ void RSDK::StartGameObjects()
 }
 
 #if RETRO_USE_MOD_LOADER
-
 void RSDK::LoadGameXML(bool pal)
 {
     FileInfo info;
@@ -787,6 +786,7 @@ void RSDK::LoadGameXML(bool pal)
                 if (pal)
                     LoadXMLPalettes(gameElement);
                 else {
+                    LoadXMLWindowText(gameElement);
                     LoadXMLObjects(gameElement);
                     LoadXMLSoundFX(gameElement);
                     LoadXMLStages(gameElement);
@@ -803,12 +803,22 @@ void RSDK::LoadGameXML(bool pal)
     SetActiveMod(-1);
 }
 
+void RSDK::LoadXMLWindowText(const tinyxml2::XMLElement *gameElement)
+{
+    const tinyxml2::XMLElement *titleElement = gameElement->FirstChildElement("title");
+    if (titleElement) {
+        const tinyxml2::XMLAttribute *nameAttr = titleElement->FindAttribute("name");
+        if (nameAttr)
+            StrCopy(gameVerInfo.gameTitle, nameAttr->Value());
+    }
+}
+
 void RSDK::LoadXMLPalettes(const tinyxml2::XMLElement *gameElement)
 {
     const tinyxml2::XMLElement *paletteElement = gameElement->FirstChildElement("palette");
     if (paletteElement) {
         for (const tinyxml2::XMLElement *clrElement = paletteElement->FirstChildElement("color"); clrElement;
-             clrElement                             = clrElement->NextSiblingElement("color")) {
+            clrElement                             = clrElement->NextSiblingElement("color")) {
             const tinyxml2::XMLAttribute *bankAttr = clrElement->FindAttribute("bank");
             int32 bank                             = 0;
             if (bankAttr)
@@ -838,7 +848,7 @@ void RSDK::LoadXMLPalettes(const tinyxml2::XMLElement *gameElement)
         }
 
         for (const tinyxml2::XMLElement *clrsElement = paletteElement->FirstChildElement("colors"); clrsElement;
-             clrsElement                             = clrsElement->NextSiblingElement("colors")) {
+            clrsElement                             = clrsElement->NextSiblingElement("colors")) {
             const tinyxml2::XMLAttribute *bankAttr = clrsElement->FindAttribute("bank");
             int32 bank                             = 0;
             if (bankAttr)
@@ -880,7 +890,7 @@ void RSDK::LoadXMLObjects(const tinyxml2::XMLElement *gameElement)
     const tinyxml2::XMLElement *objectsElement = gameElement->FirstChildElement("objects");
     if (objectsElement) {
         for (const tinyxml2::XMLElement *objElement = objectsElement->FirstChildElement("object"); objElement;
-             objElement                             = objElement->NextSiblingElement("object")) {
+            objElement                             = objElement->NextSiblingElement("object")) {
             const tinyxml2::XMLAttribute *nameAttr = objElement->FindAttribute("name");
             const char *objName                    = "unknownObject";
             if (nameAttr)
@@ -904,7 +914,7 @@ void RSDK::LoadXMLSoundFX(const tinyxml2::XMLElement *gameElement)
     const tinyxml2::XMLElement *soundsElement = gameElement->FirstChildElement("sounds");
     if (soundsElement) {
         for (const tinyxml2::XMLElement *sfxElement = soundsElement->FirstChildElement("soundfx"); sfxElement;
-             sfxElement                             = sfxElement->NextSiblingElement("soundfx")) {
+            sfxElement                             = sfxElement->NextSiblingElement("soundfx")) {
             const tinyxml2::XMLAttribute *valAttr = sfxElement->FindAttribute("path");
             const char *sfxPath                   = "unknownSFX.wav";
             if (valAttr)
@@ -929,7 +939,7 @@ void RSDK::LoadXMLStages(const tinyxml2::XMLElement *gameElement)
 {
 
     for (const tinyxml2::XMLElement *listElement = gameElement->FirstChildElement("category"); listElement;
-         listElement                             = listElement->NextSiblingElement("category")) {
+        listElement                             = listElement->NextSiblingElement("category")) {
         SceneListInfo *list = nullptr;
         int32 listID;
 
@@ -960,7 +970,7 @@ void RSDK::LoadXMLStages(const tinyxml2::XMLElement *gameElement)
         }
 
         for (const tinyxml2::XMLElement *stgElement = listElement->FirstChildElement("stage"); stgElement;
-             stgElement                             = stgElement->NextSiblingElement("stage")) {
+            stgElement                             = stgElement->NextSiblingElement("stage")) {
             const tinyxml2::XMLAttribute *nameAttr = stgElement->FindAttribute("name");
             const char *stgName                    = "unknownStage";
             if (nameAttr)

--- a/RSDKv5/RSDK/Core/RetroEngine.hpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.hpp
@@ -646,7 +646,8 @@ void StartGameObjects();
 
 #if RETRO_USE_MOD_LOADER
 void LoadGameXML(bool pal = false);
-void LoadXMLPalettes(const tinyxml2::XMLElement* gameElement);
+void LoadXMLWindowText(const tinyxml2::XMLElement *gameElement);
+void LoadXMLPalettes(const tinyxml2::XMLElement *gameElement);
 void LoadXMLObjects(const tinyxml2::XMLElement* gameElement);
 void LoadXMLSoundFX(const tinyxml2::XMLElement* gameElement);
 void LoadXMLStages(const tinyxml2::XMLElement* gameElement);

--- a/RSDKv5/RSDK/Scene/Legacy/v3/ScriptLegacyv3.cpp
+++ b/RSDKv5/RSDK/Scene/Legacy/v3/ScriptLegacyv3.cpp
@@ -883,6 +883,14 @@ void RSDK::Legacy::v3::CheckAliasText(char *text)
     if (FindStringToken(text, "#alias", 1) != 0)
         return;
 
+#if !RETRO_USE_ORIGINAL_CODE
+    if (aliasCount >= LEGACY_v3_ALIAS_COUNT) {
+        RSDK::PrintLog(PRINT_SCRIPTERR, "SCRIPT ERROR: Too many aliases\nFILE: %s", scriptFile);
+        gameMode = ENGINE_SCRIPTERROR;
+        return;
+    }
+#endif
+
     int32 textPos     = 6;
     int32 aliasStrPos = 0;
     int32 parseMode   = 0;

--- a/RSDKv5/RSDK/Scene/Legacy/v4/ScriptLegacyv4.cpp
+++ b/RSDKv5/RSDK/Scene/Legacy/v4/ScriptLegacyv4.cpp
@@ -1050,8 +1050,11 @@ void RSDK::Legacy::v4::CheckAliasText(char *text)
 {
     if (FindStringToken(text, "publicalias", 1) == 0) {
 #if !RETRO_USE_ORIGINAL_CODE
-        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT)
-            PrintLog(PRINT_NORMAL, "WARNING: SCRIPT VALUE COUNT ABOVE MAXIMUM");
+        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT) {
+            RSDK::PrintLog(PRINT_SCRIPTERR, "SCRIPT ERROR: Too many aliases, static values, and tables\nFILE: %s", scriptFile);
+            gameMode = ENGINE_SCRIPTERROR;
+            return;
+        }
 #endif
 
         ScriptVariableInfo *variable = &scriptValueList[scriptValueListCount];
@@ -1094,8 +1097,11 @@ void RSDK::Legacy::v4::CheckAliasText(char *text)
     }
     else if (FindStringToken(text, "privatealias", 1) == 0) {
 #if !RETRO_USE_ORIGINAL_CODE
-        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT)
-            PrintLog(PRINT_NORMAL, "WARNING: SCRIPT VALUE COUNT ABOVE MAXIMUM");
+        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT) {
+            RSDK::PrintLog(PRINT_SCRIPTERR, "SCRIPT ERROR: Too many aliases, static values, and tables\nFILE: %s", scriptFile);
+            gameMode = ENGINE_SCRIPTERROR;
+            return;
+        }
 #endif
 
         ScriptVariableInfo *variable = &scriptValueList[scriptValueListCount];
@@ -1139,8 +1145,11 @@ void RSDK::Legacy::v4::CheckStaticText(char *text)
 {
     if (FindStringToken(text, "publicvalue", 1) == 0) {
 #if !RETRO_USE_ORIGINAL_CODE
-        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT)
-            PrintLog(PRINT_NORMAL, "WARNING: SCRIPT VALUE COUNT ABOVE MAXIMUM");
+        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT) {
+            RSDK::PrintLog(PRINT_SCRIPTERR, "SCRIPT ERROR: Too many aliases, static values, and tables\nFILE: %s", scriptFile);
+            gameMode = ENGINE_SCRIPTERROR;
+            return;
+        }
 #endif
 
         ScriptVariableInfo *variable = &scriptValueList[scriptValueListCount];
@@ -1191,8 +1200,11 @@ void RSDK::Legacy::v4::CheckStaticText(char *text)
     }
     else if (FindStringToken(text, "privatevalue", 1) == 0) {
 #if !RETRO_USE_ORIGINAL_CODE
-        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT)
-            PrintLog(PRINT_NORMAL, "WARNING: SCRIPT VALUE COUNT ABOVE MAXIMUM");
+        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT) {
+            RSDK::PrintLog(PRINT_SCRIPTERR, "SCRIPT ERROR: Too many aliases, static values, and tables\nFILE: %s", scriptFile);
+            gameMode = ENGINE_SCRIPTERROR;
+            return;
+        }
 #endif
 
         ScriptVariableInfo *variable = &scriptValueList[scriptValueListCount];
@@ -1248,8 +1260,11 @@ bool32 RSDK::Legacy::v4::CheckTableText(char *text)
 
     if (FindStringToken(text, "publictable", 1) == 0) {
 #if !RETRO_USE_ORIGINAL_CODE
-        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT)
-            PrintLog(PRINT_NORMAL, "WARNING: SCRIPT VALUE COUNT ABOVE MAXIMUM");
+        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT) {
+            RSDK::PrintLog(PRINT_SCRIPTERR, "SCRIPT ERROR: Too many aliases, static values, and tables\nFILE: %s", scriptFile);
+            gameMode = ENGINE_SCRIPTERROR;
+            return false;
+        }
 #endif
 
         ScriptVariableInfo *variable = &scriptValueList[scriptValueListCount];
@@ -1317,8 +1332,11 @@ bool32 RSDK::Legacy::v4::CheckTableText(char *text)
     }
     else if (FindStringToken(text, "privatetable", 1) == 0) {
 #if !RETRO_USE_ORIGINAL_CODE
-        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT)
-            PrintLog(PRINT_NORMAL, "WARNING: SCRIPT VALUE COUNT ABOVE MAXIMUM");
+        if (scriptValueListCount >= LEGACY_v4_SCRIPT_VAR_COUNT) {
+            RSDK::PrintLog(PRINT_SCRIPTERR, "SCRIPT ERROR: Too many aliases, static values, and tables\nFILE: %s", scriptFile);
+            gameMode = ENGINE_SCRIPTERROR;
+            return false;
+        }
 #endif
 
         ScriptVariableInfo *variable = &scriptValueList[scriptValueListCount];

--- a/RSDKv5/RSDK/Storage/Legacy/UserStorageLegacy.cpp
+++ b/RSDKv5/RSDK/Storage/Legacy/UserStorageLegacy.cpp
@@ -71,40 +71,44 @@ void RSDK::Legacy::v4::SetLeaderboard(int32 *leaderboardID, int32 *score)
 void RSDK::Legacy::v4::HapticEffect(int32 *id, int32 *unknown1, int32 *unknown2, int32 *unknown3) {}
 
 enum NotifyCallbackIDs {
-    NOTIFY_DEATH_EVENT        = 128,
-    NOTIFY_TOUCH_SIGNPOST     = 129,
-    NOTIFY_HUD_ENABLE         = 130,
-    NOTIFY_ADD_COIN           = 131,
-    NOTIFY_KILL_ENEMY         = 132,
-    NOTIFY_SAVESLOT_SELECT    = 133,
-    NOTIFY_FUTURE_PAST        = 134,
-    NOTIFY_GOTO_FUTURE_PAST   = 135,
-    NOTIFY_BOSS_END           = 136,
-    NOTIFY_SPECIAL_END        = 137,
-    NOTIFY_DEBUGPRINT         = 138,
-    NOTIFY_KILL_BOSS          = 139,
-    NOTIFY_TOUCH_EMERALD      = 140,
-    NOTIFY_STATS_ENEMY        = 141,
-    NOTIFY_STATS_CHARA_ACTION = 142,
-    NOTIFY_STATS_RING         = 143,
-    NOTIFY_STATS_MOVIE        = 144,
-    NOTIFY_STATS_PARAM_1      = 145,
-    NOTIFY_STATS_PARAM_2      = 146,
-    NOTIFY_CHARACTER_SELECT   = 147,
-    NOTIFY_SPECIAL_RETRY      = 148,
-    NOTIFY_TOUCH_CHECKPOINT   = 149,
-    NOTIFY_ACT_FINISH         = 150,
-    NOTIFY_1P_VS_SELECT       = 151,
-    NOTIFY_CONTROLLER_SUPPORT = 152,
-    NOTIFY_STAGE_RETRY        = 153,
-    NOTIFY_SOUND_TRACK        = 154,
-    NOTIFY_GOOD_ENDING        = 155,
-    NOTIFY_BACK_TO_MAINMENU   = 156,
-    NOTIFY_LEVEL_SELECT_MENU  = 157,
-    NOTIFY_PLAYER_SET         = 158,
-    NOTIFY_EXTRAS_MODE        = 159,
-    NOTIFY_SPIN_DASH_TYPE     = 160,
-    NOTIFY_TIME_OVER          = 161,
+    NOTIFY_DEATH_EVENT         = 128,
+    NOTIFY_TOUCH_SIGNPOST      = 129,
+    NOTIFY_HUD_ENABLE          = 130,
+    NOTIFY_ADD_COIN            = 131,
+    NOTIFY_KILL_ENEMY          = 132,
+    NOTIFY_SAVESLOT_SELECT     = 133,
+    NOTIFY_FUTURE_PAST         = 134,
+    NOTIFY_GOTO_FUTURE_PAST    = 135,
+    NOTIFY_BOSS_END            = 136,
+    NOTIFY_SPECIAL_END         = 137,
+    NOTIFY_DEBUGPRINT          = 138,
+    NOTIFY_KILL_BOSS           = 139,
+    NOTIFY_TOUCH_EMERALD       = 140,
+    NOTIFY_STATS_ENEMY         = 141,
+    NOTIFY_STATS_CHARA_ACTION  = 142,
+    NOTIFY_STATS_RING          = 143,
+    NOTIFY_STATS_MOVIE         = 144,
+    NOTIFY_STATS_PARAM_1       = 145,
+    NOTIFY_STATS_PARAM_2       = 146,
+    NOTIFY_CHARACTER_SELECT    = 147,
+    NOTIFY_SPECIAL_RETRY       = 148,
+    NOTIFY_TOUCH_CHECKPOINT    = 149,
+    NOTIFY_ACT_FINISH          = 150,
+    NOTIFY_1P_VS_SELECT        = 151,
+    NOTIFY_CONTROLLER_SUPPORT  = 152,
+    NOTIFY_STAGE_RETRY         = 153,
+    NOTIFY_SOUND_TRACK         = 154,
+    NOTIFY_GOOD_ENDING         = 155,
+    NOTIFY_BACK_TO_MAINMENU    = 156,
+    NOTIFY_LEVEL_SELECT_MENU   = 157,
+    NOTIFY_PLAYER_SET          = 158,
+    NOTIFY_EXTRAS_MODE         = 159,
+    NOTIFY_SPIN_DASH_TYPE      = 160,
+    NOTIFY_TIME_OVER           = 161,
+    NOTIFY_TIMEATTACK_MODE     = 162,
+    NOTIFY_STATS_BREAK_OBJECT  = 163,
+    NOTIFY_STATS_SAVE_FUTURE   = 164,
+    NOTIFY_STATS_CHARA_ACTION2 = 165,
 };
 
 void RSDK::Legacy::v4::NotifyCallback(int32 *callback, int32 *param1, int32 *param2, int32 *param3)
@@ -117,14 +121,24 @@ void RSDK::Legacy::v4::NotifyCallback(int32 *callback, int32 *param1, int32 *par
         case NOTIFY_DEATH_EVENT: PrintLog(PRINT_NORMAL, "NOTIFY: DeathEvent() -> %d", *param1); break;
         case NOTIFY_TOUCH_SIGNPOST: PrintLog(PRINT_NORMAL, "NOTIFY: TouchSignPost() -> %d", *param1); break;
         case NOTIFY_HUD_ENABLE: PrintLog(PRINT_NORMAL, "NOTIFY: HUDEnable() -> %d", *param1); break;
-        case NOTIFY_ADD_COIN: PrintLog(PRINT_NORMAL, "NOTIFY: AddCoin() -> %d", *param1); break;
+        case NOTIFY_ADD_COIN:
+            PrintLog(PRINT_NORMAL, "NOTIFY: AddCoin() -> %d", *param1);
+            SetGlobalVariableByName("game.coinCount", GetGlobalVariableByName("game.coinCount") + *param1);
+            break;
         case NOTIFY_KILL_ENEMY: PrintLog(PRINT_NORMAL, "NOTIFY: KillEnemy() -> %d", *param1); break;
         case NOTIFY_SAVESLOT_SELECT: PrintLog(PRINT_NORMAL, "NOTIFY: SaveSlotSelect() -> %d", *param1); break;
         case NOTIFY_FUTURE_PAST: PrintLog(PRINT_NORMAL, "NOTIFY: FuturePast() -> %d", *param1); break;
         case NOTIFY_GOTO_FUTURE_PAST: PrintLog(PRINT_NORMAL, "NOTIFY: GotoFuturePast() -> %d", *param1); break;
         case NOTIFY_BOSS_END: PrintLog(PRINT_NORMAL, "NOTIFY: BossEnd() -> %d", *param1); break;
         case NOTIFY_SPECIAL_END: PrintLog(PRINT_NORMAL, "NOTIFY: SpecialEnd() -> %d", *param1); break;
-        case NOTIFY_DEBUGPRINT: PrintLog(PRINT_NORMAL, "NOTIFY: DebugPrint() -> %d, %d, %d", *param1, *param2, *param3); break;
+        case NOTIFY_DEBUGPRINT:
+            // This callback can be called with either CallNativeFunction2 or CallNativeFunction4
+            // todo: find a better way to check for which one was used
+            if (*param2 == 264865096)
+                PrintLog(PRINT_NORMAL, "NOTIFY: DebugPrint() -> %d", *param1);
+            else
+                PrintLog(PRINT_NORMAL, "NOTIFY: DebugPrint() -> %d, %d, %d", *param1, *param2, *param3);
+            break;
         case NOTIFY_KILL_BOSS: PrintLog(PRINT_NORMAL, "NOTIFY: KillBoss() -> %d", *param1); break;
         case NOTIFY_TOUCH_EMERALD: PrintLog(PRINT_NORMAL, "NOTIFY: TouchEmerald() -> %d", *param1); break;
         case NOTIFY_STATS_ENEMY: PrintLog(PRINT_NORMAL, "NOTIFY: StatsEnemy() -> %d, %d, %d", *param1, *param2, *param3); break;
@@ -164,5 +178,9 @@ void RSDK::Legacy::v4::NotifyCallback(int32 *callback, int32 *param1, int32 *par
         case NOTIFY_EXTRAS_MODE: PrintLog(PRINT_NORMAL, "NOTIFY: ExtrasMode() -> %d", *param1); break;
         case NOTIFY_SPIN_DASH_TYPE: PrintLog(PRINT_NORMAL, "NOTIFY: SpindashType() -> %d", *param1); break;
         case NOTIFY_TIME_OVER: PrintLog(PRINT_NORMAL, "NOTIFY: TimeOver() -> %d", *param1); break;
+        case NOTIFY_TIMEATTACK_MODE: PrintLog(PRINT_NORMAL, "NOTIFY: TimeAttackMode() -> %d", *param1); break;
+        case NOTIFY_STATS_BREAK_OBJECT: PrintLog(PRINT_NORMAL, "NOTIFY: StatsBreakObject() -> %d, %d", *param1, *param2); break;
+        case NOTIFY_STATS_SAVE_FUTURE: PrintLog(PRINT_NORMAL, "NOTIFY: StatsSaveFuture() -> %d", *param1); break;
+        case NOTIFY_STATS_CHARA_ACTION2: PrintLog(PRINT_NORMAL, "NOTIFY: StatsCharaAction2() -> %d, %d, %d", *param1, *param2, *param3); break;
     }
 }

--- a/RSDKv5/RSDK/User/Dummy/DummyCore.hpp
+++ b/RSDKv5/RSDK/User/Dummy/DummyCore.hpp
@@ -10,7 +10,7 @@ struct DummyCore : UserCore {
         valueCount = 1;
 
 #if !RSDK_AUTOBUILD
-        // disable plus on autobuilds
+        // enable dlc
         for (int32 v = 0; v < valueCount; ++v) values[v] = true;
 #endif
     }

--- a/android/app/src/main/java/org/rems/rsdkv5/Launcher.java
+++ b/android/app/src/main/java/org/rems/rsdkv5/Launcher.java
@@ -208,7 +208,7 @@ public class Launcher extends AppCompatActivity {
                     })
                     .setNeutralButton("Change Path", (dialog, i) -> {
                         timer.cancel();
-                            getContentResolver().releasePersistableUriPermission(basePath, takeFlags);
+                        getContentResolver().releasePersistableUriPermission(basePath, takeFlags);
                         folderPicker();
                     })
                     .create();


### PR DESCRIPTION
- Added a check to set `game.hasPlusDLC` based on the `RSDK_AUTOBUILD` flag in v4 (and v3 if the mod loader is enabled)
- Added the ability to set the game title through game.xml (works in all versions)
- Updated the v3 RetroEngineCallback and v4 NotifyCallback ID lists and callbacks
- Overloading the script var count in v4 now throws a script error in-game instead of printing a warning in the log (this was also added for the alias count in v3)
- The `engine.standalone` global variable is now forced to 0 in v3/v4 when the mod loader is enabled

This PR doesn't include the Origins Plus collision/hitbox stuff as I don't know if Leonx254 wants to make his own PR for that