### PR TITLE
Misc fixes and improvements

### DIFF
--- a/RSDKv5/RSDK/Audio/Legacy/AudioLegacy.cpp
+++ b/RSDKv5/RSDK/Audio/Legacy/AudioLegacy.cpp
@@ -85,7 +85,7 @@ void RSDK::Legacy::LoadSfx(char *filename, uint8 slot, uint8 scope)
 
 void RSDK::Legacy::v3::SetSfxAttributes(int32 channelID, int32 loop, int8 pan)
 {
-    if (channelID < 0 || channelID > CHANNEL_COUNT)
+    if (channelID < 0 || channelID >= CHANNEL_COUNT)
         return;
 
     if (channels[channelID].state == CHANNEL_SFX) {

--- a/RSDKv5/RSDK/Core/ModAPI.cpp
+++ b/RSDKv5/RSDK/Core/ModAPI.cpp
@@ -215,7 +215,7 @@ void RSDK::SortMods()
         }
     }
 
-    std::stable_sort(modList.begin(), modList.end(), [](ModInfo a, ModInfo b) {
+    std::stable_sort(modList.begin(), modList.end(), [](const ModInfo& a, const ModInfo& b) {
         if (!(a.active && b.active))
             return a.active;
         // keep it unsorted i guess
@@ -428,7 +428,7 @@ bool32 RSDK::ScanModFolder(ModInfo *info, const char *targetFile, bool32 fromLoa
                     RenderDevice::FlipScreen();
                 }
             }
-        } catch (fs::filesystem_error fe) {
+        } catch (fs::filesystem_error& fe) {
             PrintLog(PRINT_ERROR, "Mod File Scanning Error: %s", fe.what());
         }
     }
@@ -572,7 +572,7 @@ void RSDK::LoadMods(bool newOnly, bool32 getVersion)
                     }
                 }
             }
-        } catch (fs::filesystem_error fe) {
+        } catch (fs::filesystem_error& fe) {
             PrintLog(PRINT_ERROR, "Mods folder scanning error: %s", fe.what());
         }
     }
@@ -587,7 +587,7 @@ void RSDK::LoadMods(bool newOnly, bool32 getVersion)
     LoadModSettings();
 }
 
-void loadCfg(ModInfo *info, std::string path)
+void loadCfg(ModInfo *info, const std::string& path)
 {
     FileInfo cfg;
     InitFileInfo(&cfg);
@@ -621,7 +621,7 @@ void loadCfg(ModInfo *info, std::string path)
     }
 }
 
-bool32 RSDK::LoadMod(ModInfo *info, std::string modsPath, std::string folder, bool32 active, bool32 getVersion)
+bool32 RSDK::LoadMod(ModInfo *info, const std::string& modsPath, const std::string& folder, bool32 active, bool32 getVersion)
 {
     if (!info)
         return false;
@@ -1512,7 +1512,7 @@ bool32 RSDK::ForeachSetting(const char *id, String *setting)
 }
 #endif
 
-void SetModSettingsValue(const char *key, std::string val)
+void SetModSettingsValue(const char *key, const std::string& val)
 {
     if (!currentMod)
         return;

--- a/RSDKv5/RSDK/Core/ModAPI.hpp
+++ b/RSDKv5/RSDK/Core/ModAPI.hpp
@@ -238,7 +238,7 @@ inline void SetActiveMod(int32 id) { modSettings.activeMod = id; }
 void InitModAPI(bool32 getVersion = false);
 void UnloadMods();
 void LoadMods(bool newOnly = false, bool32 getVersion = false);
-bool32 LoadMod(ModInfo *info, std::string modsPath, std::string folder, bool32 active, bool32 getVersion = false);
+bool32 LoadMod(ModInfo *info, const std::string& modsPath, const std::string& folder, bool32 active, bool32 getVersion);
 void SaveMods();
 void SortMods();
 void LoadModSettings();
@@ -290,7 +290,7 @@ Object *ModFindObject(const char *name);
 
 void *GetGlobals();
 
-bool32 LoadModInfo(const char *folder, String *name, String *description, String *version, bool32 *active);
+bool32 LoadModInfo(const char *id, String *name, String *description, String *version, bool32 *active);
 void GetModPath(const char *id, String *result);
 int32 GetModCount(bool32 active);
 const char *GetModIDByIndex(uint32 index);

--- a/RSDKv5/RSDK/Graphics/Sprite.cpp
+++ b/RSDKv5/RSDK/Graphics/Sprite.cpp
@@ -991,7 +991,7 @@ bool32 RSDK::LoadImage(const char *filename, double displayLength, double fadeSp
         if (image.width == RETRO_VIDEO_TEXTURE_W && image.height == RETRO_VIDEO_TEXTURE_H) {
             RenderDevice::SetupImageTexture(image.width, image.height, image.pixels);
         }
-#if !RETRO_USING_ORIGINAL_CODE
+#if !RETRO_USE_ORIGINAL_CODE
         else {
             PrintLog(PRINT_NORMAL, "ERROR: Images must be 1024x512!");
         }
@@ -1007,10 +1007,7 @@ bool32 RSDK::LoadImage(const char *filename, double displayLength, double fadeSp
         sceneInfo.state           = ENGINESTATE_SHOWIMAGE;
         engine.imageFadeSpeed     = fadeSpeed / 60.0;
 
-#if RETRO_USE_ORIGINAL_CODE
-        image.palette = NULL;
-#endif
-        image.pixels  = NULL;
+        image.pixels = NULL;
         image.Close();
         return true;
     }
@@ -1019,7 +1016,7 @@ bool32 RSDK::LoadImage(const char *filename, double displayLength, double fadeSp
         if (image.width == RETRO_VIDEO_TEXTURE_W && image.height == RETRO_VIDEO_TEXTURE_H) {
             RenderDevice::SetupImageTexture(image.width, image.height, image.pixels);
         }
-#if !RETRO_USING_ORIGINAL_CODE
+#if !RETRO_USE_ORIGINAL_CODE
         else {
             PrintLog(PRINT_NORMAL, "ERROR: Images must be 1024x512!");
         }
@@ -1035,19 +1032,13 @@ bool32 RSDK::LoadImage(const char *filename, double displayLength, double fadeSp
         sceneInfo.state           = ENGINESTATE_SHOWIMAGE;
         engine.imageFadeSpeed     = fadeSpeed / 60.0;
 
-#if RETRO_USE_ORIGINAL_CODE
-        image.palette = NULL;
-#endif
-        image.pixels  = NULL;
+        image.pixels = NULL;
         image.Close();
         return true;
     }
 #endif
     else {
-#if RETRO_USE_ORIGINAL_CODE
-        image.palette = NULL;
-#endif
-        image.pixels  = NULL;
+        image.pixels = NULL;
         image.Close();
     }
     return false;

--- a/RSDKv5/RSDK/Graphics/Sprite.cpp
+++ b/RSDKv5/RSDK/Graphics/Sprite.cpp
@@ -952,6 +952,16 @@ uint16 RSDK::LoadSpriteSheet(const char *filename, uint8 scope)
 
         surface->pixels = NULL;
         AllocateStorage((void **)&surface->pixels, surface->width * surface->height, DATASET_STG, false);
+#if !RETRO_USE_ORIGINAL_CODE
+        // Bug details: On a failed allocation, image.pixels will end up being reallocated in image.Load().
+        // Pixel data would then be loaded in this temporary buffer, but surface->pixels would never point to the actual data.
+        // This issue would only happen on cases where the STG mempool is full, such as ports with lower storage limits
+        // or with mods that use a lot of spritesheets.
+        // As a last resort, let's try a new allocation in TMP for surface->pixels.
+        // NOTE: This is a workaround, and will still cause a crash if the TMP allocation fails as well.
+        if (!surface->pixels)
+            AllocateStorage((void **)&surface->pixels, surface->width * surface->height, DATASET_TMP, false);
+#endif
         image.pixels = surface->pixels;
         image.Load(NULL, false);
 

--- a/RSDKv5/RSDK/User/Core/UserAchievements.cpp
+++ b/RSDKv5/RSDK/User/Core/UserAchievements.cpp
@@ -123,9 +123,6 @@ void RSDK::SKU::ProcessAchievements()
                     InitString(&achievementStrings[0], achievementText.c_str(), 0);
                     String buffer;
                     CopyString(&achievementStrings[1], achievements->GetAchievementName(&buffer, achievementID));
-#if !RETRO_USE_ORIGINAL_CODE
-                    RemoveStorageEntry((void**)&buffer);
-#endif
 
                     if (curSKU.language == LANGUAGE_JP) {
                         achievementStringWidth[0] = 13 * achievementStrings[0].length;
@@ -161,9 +158,6 @@ void RSDK::SKU::DrawAchievements()
             InitString(&achievementStrings[0], achievementText.c_str(), 0);
             String buffer;
             CopyString(&achievementStrings[1], achievements->GetAchievementName(&buffer, achievementID));
-#if !RETRO_USE_ORIGINAL_CODE
-            RemoveStorageEntry((void**)&buffer);
-#endif
 
             int32 drawX = achievementStrX + currentScreen->size.x - achievementStrW;
             DrawRectangle(drawX, currentScreen->size.y - 40, achievementStrW - achievementStrX, 40, 0xFF107C, 0x10, INK_NONE, true);


### PR DESCRIPTION
Hoping to fix most of the remaining ModAPI issues and improve performance a bit. Fix some remaining decomp inaccuracies as well.

**ModAPI:**
- - [X] Use const ref on most parameters to avoid unnecessary copies
- ~~Investigate crash on Wii when loading SSZ2M ---> seems to be `ModInfo` related, sort of mitigated by not sorting mods?~~ Out of scope.

Other fixes:
- - [X] AudioLegacy: Fix potential out of bounds channel access (`channelID == 0x10`)
- - [X] Revert "UserAchievements: Free local variables" (invalid free which would also end up triggering a bug)
- - [X] LoadImage: Fix memory leak (image.palette getting assigned to NULL, preventing deallocation)
- - [X] LoadSpritesheet: Check for failed allocation (fix TMP allocation workaround when STG is full)
- ~~Investigate 3DS crash on exit ---> seems to be `UserAchievements` related, during destructor call ([more info](https://github.com/SaturnSH2x2/RSDKv5-Decompilation/pull/4#issuecomment-1537118063))~~ Out of scope, the global variable `achievementList` seems to get its destructor called twice, probably a weird 3DS devkitpro bug that doesn't happen anywhere else.