### PR TITLE
CMake documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ We do not condone using this project as a means for piracy in any form. This pro
 * Added a built-in shader compiler for backends/platforms that support it.
 * Added various other backends to windows aside from the usual DirectX 9 backends
 
-## If you are here for Sonic Mania's source code:
-You probably want to head to [the Sonic Mania Decompilation repo](https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation) instead.
+## If you are here for Sonic Mania:
+You have the option of building RSDKv5 alongside Mania in [the Sonic Mania Decompilation repo](https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation).
 
 # How to Build
 
-This project uses [CMake](https://cmake.org/), a versatile building system that supports many different compilers and platforms. You can download CMake [here](https://cmake.org/download/). **(Make sure to enable the feature to add CMake to the system PATH during the installation!)**
+This project uses [CMake](https://cmake.org/), a versatile building system that supports many different compilers and platforms. You can download CMake [here](https://cmake.org/download/). **(Make sure to enable the feature to add CMake to the system PATH during the installation if you're on Windows!)**
 
 ## Get the source code
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ We do not condone using this project as a means for piracy in any form. This pro
 * Added a built-in shader compiler for backends/platforms that support it.
 * Added various other backends to windows aside from the usual DirectX 9 backends
 
-## If you are here for Sonic Mania:
-You probably want [the dedicated Sonic Mania repo](https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation) instead.
+## If you are here for Sonic Mania's source code:
+You probably want to head to [the Sonic Mania Decompilation repo](https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation) instead.
 
 # How to Build
 
+This project uses [CMake](https://cmake.org/), a versatile building system that supports many different compilers and platforms. You can download CMake [here](https://cmake.org/download/). **(Make sure to enable the feature to add CMake to the system PATH during the installation!)**
+
 ## Get the source code
+
+In order to clone the repository, you need to install Git, which you can get [here](https://git-scm.com/downloads).
 
 Clone the repo **recursively**, using:
 `git clone --recursive https://github.com/Rubberduckycooly/RSDKv5-Decompilation`
@@ -29,17 +33,21 @@ If you've already cloned the repo, run this command inside of the repository:
 ## Follow the build steps
 
 ### Windows
-[Install vcpkg](https://github.com/microsoft/vcpkg#quick-start-windows), then run the following:
-- `[vcpkg root]\vcpkg.exe install libtheora libogg --triplet=x64-windows-static` (the triplet can be whatever preferred)
+To handle dependencies, you'll need to install [Visual Studio Community](https://visualstudio.microsoft.com/downloads/) (make sure to install the `Desktop development with C++` package during the installation) and [vcpkg](https://github.com/microsoft/vcpkg#quick-start-windows).
 
-Finally, follow the [compilation steps below](#compiling) using `-DCMAKE_TOOLCHAIN_FILE=[vcpkg root]/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=(chosen triplet)` as arguments for `cmake ..`.
+After installing those, run the following in Command Prompt (make sure to replace `[vcpkg root]` with the path to the vcpkg installation!):
+- `[vcpkg root]/vcpkg.exe install libtheora libogg --triplet=x64-windows-static` (If you're compiling a 32-bit build, replace `x64-windows-static` with `x86-windows-static`.)
+
+Finally, follow the [compilation steps below](#compiling) using `-DCMAKE_TOOLCHAIN_FILE=[vcpkg root]/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static` as arguments for `cmake -B build`.
+  - Make sure to replace `[vcpkg root]` with the path to the vcpkg installation!
+  - If you're compiling a 32-bit build, replace `x64-windows-static` with `x86-windows-static`.
 
 ### Linux
 Install the following dependencies: then follow the [compilation steps below](#compiling):
 - **pacman (Arch):** `sudo pacman -S base-devel glew glfw libtheora portaudio`
 - **apt (Debian/Ubuntu):** `sudo apt install build-essential libglew-dev libglfw3-dev libtheora-dev portaudio19-dev`
 - **rpm (Fedora):** `sudo dnf install make gcc glew-devel glfw-devel libtheora-devel zlib-devel portaudio`
-- Your favorite package manager here, [make a pull request](https://github.com/Rubberduckycooly/RSDKv5-Decompilation/fork) (also update Mania!)
+- Your favorite package manager here, [make a pull request](https://github.com/Rubberduckycooly/RSDKv5-Decompilation/fork) (also update [Mania](https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation)!)
 
 #### (make sure to [install GL shaders!](FAQ.md#q-why-arent-videosfilters-working-while-using-gl))
 
@@ -47,7 +55,7 @@ Install the following dependencies: then follow the [compilation steps below](#c
 [Setup devKitPro](https://devkitpro.org/wiki/Getting_Started), then run the following:
 - `(dkp-)pacman -Syuu switch-dev switch-libogg switch-libtheora switch-sdl2 switch-glad`
 
-Finally, follow the [compilation steps below](#compiling) using `-DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/Platform/Switch.cmake` as arguments for `cmake ..`.
+Finally, follow the [compilation steps below](#compiling) using `-DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/Platform/Switch.cmake` as arguments for `cmake -B build`.
 
 #### (make sure to [install GL shaders!](FAQ.md#q-why-arent-videosfilters-working-while-using-gl))
 
@@ -56,23 +64,23 @@ Follow the android build instructions [here.](./dependencies/android/README.md)
 
 ### Compiling
 
-Compiling is as simple as typing the following:
+Compiling is as simple as typing the following in the root repository directory:
 ```
-cmake -Bbuild # arguments go here
-cmake --build build
+cmake -B build
+cmake --build build --config release
 ```
 
 The resulting build will be located somewhere in `build/` depending on your system.
 
 The following cmake arguments are available when compiling:
-- Use these on the `cmake ..` step like so: `cmake .. -DRETRO_DISABLE_PLUS=on`
+- Use these on the `cmake -B build` step like so: `cmake -B build -DRETRO_DISABLE_PLUS=on`
 
 ### RSDKv5 flags
 - `RETRO_REVISION`: What revision to compile for. Takes an integer, defaults to `3` (RSDKv5U).
 - `RETRO_DISABLE_PLUS`: Whether or not to disable the Plus DLC. Takes a boolean (on/off): build with `on` when compiling for distribution. Defaults to `off`.
 - `RETRO_MOD_LOADER`: Enables or disables the mod loader. Takes a boolean, defaults to `on`.
 - `RETRO_MOD_LOADER_VER`: Manually sets the mod loader version. Takes an integer, defaults to the current latest version.
-- `RETRO_SUBSYSTEM`: *Only change this if you know what you're doing.* Changes the subsystem that RSDKv5 will be built for. Defaults to the most standard subsystem for the platform.   
+- `RETRO_SUBSYSTEM`: *Only change this if you know what you're doing.* Changes the subsystem that RSDKv5 will be built for. Defaults to the most standard subsystem for the platform.
 
 ## Other Platforms
 Currently, the only officially supported platforms are the ones listed above.

--- a/dependencies/android/README.md
+++ b/dependencies/android/README.md
@@ -6,6 +6,8 @@
 
 * libtheora: [Download](https://xiph.org/downloads/) and unzip it in `dependencies/android/libtheora`.
 
+## Set up symlinks
+
 * Ensure the symbolic links in `[root]/android/app/jni` are correct: 
   * `RSDKv5` -> root of the RSDKv5 repository
   * `Game` -> root of the Mania repository (or any other game that you may be compiling)

--- a/dependencies/ogl/.gitignore
+++ b/dependencies/ogl/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/dependencies/ogl/README.md
+++ b/dependencies/ogl/README.md
@@ -1,6 +1,6 @@
 # Linux/Switch
 
-**This document was intended for an outdated method of building this decompilation and is only left in this repository for reference purposes. It's highly recommended to follow the [CMake guide](./../README.md#how-to-build) instead.**
+**This document was intended for a now outdated method of building this decompilation and is only left in this repository for reference purposes. It's highly recommended to follow the [CMake guide](./../../README.md#how-to-build) instead.**
 
 ## Installing GL3 dependencies 
 

--- a/dependencies/ogl/README.md
+++ b/dependencies/ogl/README.md
@@ -1,0 +1,48 @@
+# Linux/Switch
+
+**This document was intended for an outdated method of building this decompilation and is only left in this repository for reference purposes. It's highly recommended to follow the [CMake guide](./../README.md#how-to-build) instead.**
+
+## Installing GL3 dependencies 
+
+The OpenGL3 backend is mainly used on Linux and Switch, but it does support Windows too.
+
+For Windows, these need to be downloaded and extracted in their respective subdirectories 
+- **GLEW:** Download from [SourceForge](http://glew.sourceforge.net/), extract it in `dependencies/ogl/glew`
+- **GLFW:** Download from [the official site](https://www.glfw.org/download.html), extract it in `dependencies/ogl/glfw`  
+  There are also 32-bit binaries available if you need them, but make sure the RSDKv5(U) is built for 32-bit too!
+
+For Switch you'll need [devkitPro](https://devkitpro.org/) and GLAD, as GLEW and GLFW are not available. Install GLAD with `sudo dkp-pacman -S switch-glad`
+
+For Linux you can install the dependencies using your distro package manager:
+- **Arch Linux:** `sudo pacman -S base-devel glew glfw libtheora zlib sdl2`
+- **Ubuntu (20.04+) or Debian (11+):** `sudo apt install build-essential libglew-dev libglfw3-dev libtheora-dev zlib1g-dev libsdl2-dev`
+- **Fedora:** `sudo dnf install make gcc glew-devel glfw-devel libtheora-devel zlib-devel SDL2-devel`
+
+## Compiling 
+
+To compile you can just use `make`. To customize the build you can set the following options
+- `PLATFORM=Switch`: Build for Nintendo Switch.
+- `RSDK_REVISION=2`: Compile regular RSDKv5 instead of RSDKv5U.
+- `RSDK_ONLY=1`: Only build the engine (no Game.so)
+- `AUTOBUILD=1`: Disable the Plus DLC, which you should do if you plan on distributing the binary.
+
+## Shaders 
+
+Once completed, it is **heavily recommended** that you grab the Shaders folder in RSDKv5 and turn it into a mod. Otherwise, movies will not display properly and the filters from video settings won't work.
+
+To do this, create the following directory structure inside your mods directory:
+```
+GLShaders/
+| Data/
+| | ...
+| mod.ini
+```
+
+Inside `mods/GLShaders/Data/` copy the `RSDKv5/Shaders` directory, and inside the mod.ini, paste this:
+```
+Name=GLShaders
+Description=GL3 shaders to enable filters and stuff
+Author=Ducky
+Version=1.0.0
+TargetVersion=5
+```

--- a/dependencies/windows/.gitignore
+++ b/dependencies/windows/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/dependencies/windows/README.md
+++ b/dependencies/windows/README.md
@@ -1,0 +1,20 @@
+# Windows
+
+**This document was intended for an outdated method of building this decompilation and is only left in this repository for reference purposes. It's highly recommended to follow the [CMake guide](./../README.md#how-to-build) instead.**
+
+## Installing dependencies 
+
+* libogg: https://xiph.org/downloads/ (libogg)
+  * Download libogg and unzip it in "./libogg/", then build the static library
+
+* libtheora: https://www.theora.org/downloads/ 
+  * Download **the 1.2.0 alpha release** and unzip it in "./libtheora/", then build the VS2010 static library (win32/VS2010/libtheora_static.sln)
+
+* SDL2 (Required for SDL2 backends): https://www.libsdl.org/download-2.0.php
+  * Download the appropriate development library for your compiler and unzip it in "./SDL2/"
+
+* For the OGL backends, visit the OGL README [here.](../ogl/README.md)
+
+## Compiling
+
+* Build via the Visual Studio solution (or grab a prebuilt executable from the releases section.)

--- a/dependencies/windows/README.md
+++ b/dependencies/windows/README.md
@@ -1,6 +1,6 @@
 # Windows
 
-**This document was intended for an outdated method of building this decompilation and is only left in this repository for reference purposes. It's highly recommended to follow the [CMake guide](./../README.md#how-to-build) instead.**
+**This document was intended for a now outdated method of building this decompilation and is only left in this repository for reference purposes. It's highly recommended to follow the [CMake guide](./../../README.md#how-to-build) instead.**
 
 ## Installing dependencies 
 


### PR DESCRIPTION
This carries over some of the improvements to the CMake documentation/building instructions made in the RSDKv3 and RSDKv4 repositories, and generally cleans up some minor things.