### PR TITLE
GLFW/EGL: Free file buffers after shader compilation

### DIFF
--- a/RSDKv5/RSDK/Graphics/EGL/EGLRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/EGL/EGLRenderDevice.cpp
@@ -895,6 +895,7 @@ void RenderDevice::LoadShader(const char *fileName, bool32 linear)
         vert                   = glCreateShader(GL_VERTEX_SHADER);
         glShaderSource(vert, 4, glchar, NULL);
         glCompileShader(vert);
+        RemoveStorageEntry((void **)&fileData);
 
         glGetShaderiv(vert, GL_COMPILE_STATUS, &success);
         if (!success) {
@@ -919,6 +920,7 @@ void RenderDevice::LoadShader(const char *fileName, bool32 linear)
         frag                   = glCreateShader(GL_FRAGMENT_SHADER);
         glShaderSource(frag, 4, glchar, NULL);
         glCompileShader(frag);
+        RemoveStorageEntry((void **)&fileData);
 
         glGetShaderiv(frag, GL_COMPILE_STATUS, &success);
         if (!success) {

--- a/RSDKv5/RSDK/Graphics/GLFW/GLFWRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/GLFW/GLFWRenderDevice.cpp
@@ -761,6 +761,7 @@ void RenderDevice::LoadShader(const char *fileName, bool32 linear)
         vert                   = glCreateShader(GL_VERTEX_SHADER);
         glShaderSource(vert, 3, glchar, NULL);
         glCompileShader(vert);
+        RemoveStorageEntry((void **)&fileData);
 
         glGetShaderiv(vert, GL_COMPILE_STATUS, &success);
         if (!success) {
@@ -785,6 +786,7 @@ void RenderDevice::LoadShader(const char *fileName, bool32 linear)
         frag                   = glCreateShader(GL_FRAGMENT_SHADER);
         glShaderSource(frag, 3, glchar, NULL);
         glCompileShader(frag);
+        RemoveStorageEntry((void **)&fileData);
 
         glGetShaderiv(frag, GL_COMPILE_STATUS, &success);
         if (!success) {


### PR DESCRIPTION
Avoids stack use after free errors in ASan.