### PR TITLE
Fixed Switch's incorrect button layout & Case Insensitivity

### DIFF
--- a/RSDKv5/RSDK/Core/Reader.cpp
+++ b/RSDKv5/RSDK/Core/Reader.cpp
@@ -241,9 +241,12 @@ bool32 RSDK::LoadFile(FileInfo *info, const char *filename, uint8 fileMode)
     strcpy(fullFilePath, filename);
 
 #if RETRO_USE_MOD_LOADER
+    // Fixes ".ani" ".Ani" bug and any other case differences
     char pathLower[0x100];
-    memset(pathLower, 0, sizeof(pathLower));
-    for (int32 c = 0; c < strlen(filename); ++c) pathLower[c] = tolower(filename[c]);
+    memset(pathLower, 0, sizeof(char) * 0x100);
+    for (int32 c = 0; c < strlen(fullFilePath); ++c) {
+        pathLower[c] = tolower(fullFilePath[c]);
+    }
 
     bool32 addPath = false;
     int32 m        = modSettings.activeMod != -1 ? modSettings.activeMod : 0;
@@ -263,7 +266,7 @@ bool32 RSDK::LoadFile(FileInfo *info, const char *filename, uint8 fileMode)
         }
         if (modSettings.activeMod != -1) {
             PrintLog(PRINT_NORMAL, "[MOD] Failed to find file %s in active mod %s", filename, modList[m].id.c_str());
-            // TODO return false? check original impl later
+            break; // no one ever checked the original implementation... :pensive:
         }
     }
 

--- a/RSDKv5/RSDK/Core/Reader.cpp
+++ b/RSDKv5/RSDK/Core/Reader.cpp
@@ -241,7 +241,12 @@ bool32 RSDK::LoadFile(FileInfo *info, const char *filename, uint8 fileMode)
     strcpy(fullFilePath, filename);
 
 #if RETRO_USE_MOD_LOADER
-    // Fixes ".ani" ".Ani" bug and any other case differences
+    // this code is pretty much just v5's but with a little difference
+    // now it uses fullFilePath, instead of using filename for the pathLower stuff
+    // not sure of why the original code was using filename instead of the fullFilePath variable
+    // and considering how most of the code here uses fullFilePath instead of filename, it gets a bit more confusing
+    // but eh, atleast this new code works, and if it works, then that means that it got an "works on my machine" certificate :thumbsup:
+    // also before anyone asks me, nah, the memset code is literally the same but with different words, so nothing to worry in here, atleast for what i think :shrug:
     char pathLower[0x100];
     memset(pathLower, 0, sizeof(char) * 0x100);
     for (int32 c = 0; c < strlen(fullFilePath); ++c) {
@@ -266,7 +271,12 @@ bool32 RSDK::LoadFile(FileInfo *info, const char *filename, uint8 fileMode)
         }
         if (modSettings.activeMod != -1) {
             PrintLog(PRINT_NORMAL, "[MOD] Failed to find file %s in active mod %s", filename, modList[m].id.c_str());
-            break; // no one ever checked the original implementation... :pensive:
+            // TODO return false? check original impl later
+            // weirdly enough, the original impl uses a break case here
+            // but according to Mephiles, this just skips all the mods in the mod list?
+            // considering how differently v5 handles the modding API compared to v3 & v4, though
+            // it makes this having sense, but yeah, i'll prob test this code later with other stuff than the break cases
+            // but for now, have only some new comments that explain better what i changed from the og lowercase code from v5
         }
     }
 

--- a/RSDKv5/RSDK/Input/GLFW/GLFWInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/GLFW/GLFWInputDevice.cpp
@@ -132,6 +132,7 @@ RSDK::SKU::InputDeviceGLFW *RSDK::SKU::InitGLFWInputDevice(uint32 id, uint8 cont
     else if (strstr(name, "Nintendo") || strstr(name, "Switch")) {
         controllerType   = DEVICE_SWITCH_PRO;
         device->swapABXY = true;
+        engine.confirmFlip = true;
     }
     else if (strstr(name, "Saturn"))
         controllerType = DEVICE_SATURN;

--- a/RSDKv5/RSDK/Input/SDL2/SDL2InputDevice.cpp
+++ b/RSDKv5/RSDK/Input/SDL2/SDL2InputDevice.cpp
@@ -212,6 +212,7 @@ RSDK::SKU::InputDeviceSDL *RSDK::SKU::InitSDL2InputDevice(uint32 id, SDL_GameCon
         else if (strstr(name, "Switch") || strstr(name, "Wii U")) {
             controllerType   = DEVICE_SWITCH_PRO;
             device->swapABXY = true;
+            engine.confirmFlip = true;
         }
         else if (strstr(name, "Saturn"))
             controllerType = DEVICE_SATURN;


### PR DESCRIPTION
This fixes a issue where the AB/Confirm & Back buttons on NX/Switch controllers would be swapped compared to the official Mania/RSDKv5, as reported in issue #108
And also fixes a problem where the files needed to be Case Insensitive (atleast on Legacy v3 mode, for what is told in the description of it), as reported in issue #214