### PR TITLE
Support static builds for GameAPI games

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,14 +151,14 @@ endif()
 target_compile_definitions(RetroEngine PRIVATE
     RETRO_REVISION=${RETRO_REVISION}
     RSDK_USE_${RETRO_SUBSYSTEM}=1
-    
+
     RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
     RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
 
     RETRO_STANDALONE=$<NOT:$<BOOL:${GAME_STATIC}>>
-    
+
     RSDK_AUTOBUILD=$<BOOL:${RETRO_DISABLE_PLUS}>
-    
+
     RETRO_DEV_EXTRA="${PLATFORM} - ${RETRO_SUBSYSTEM} - ${CMAKE_CXX_COMPILER_ID}"
     DECOMP_VERSION="${DECOMP_VERSION}"
 )
@@ -190,16 +190,16 @@ if(WITH_RSDK)
     if (GAME_TYPE STREQUAL "1") # Sonic Mania
         target_compile_definitions(${GAME_NAME} PRIVATE
             RETRO_REVISION=${RETRO_REVISION}
-	    
+
             RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
             RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
-        
+
             GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
             GAME_VERSION=${GAME_VERSION}
-	    
+
             MANIA_PREPLUS=$<BOOL:${MANIA_PREPLUS}>
             MANIA_FIRST_RELEASE=$<BOOL:${MANIA_FIRST_RELEASE}>
-	    
+
             GAME_TYPE=${GAME_TYPE}
             GAME_NO_GLOBALS=$<BOOL:${GAME_NO_GLOBALS}>
             GAME_NO_VARIABLES=$<BOOL:${GAME_NO_VARIABLES}>
@@ -208,16 +208,16 @@ if(WITH_RSDK)
     elseif(GAME_TYPE STREQUAL "2") # Sonic 3 & Knuckles
         target_compile_definitions(${GAME_NAME} PRIVATE
             RETRO_REVISION=${RETRO_REVISION}
-	    
+
             RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
             RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
-        
+
             GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
             GAME_VERSION=${GAME_VERSION}
-	    
+
             ORIGINS_PREPLUS=$<BOOL:${ORIGINS_PREPLUS}>
             ORIGINS_FIRST_RELEASE=$<BOOL:${ORIGINS_FIRST_RELEASE}>
-	    
+
             GAME_TYPE=${GAME_TYPE}
             GAME_NO_GLOBALS=$<BOOL:${GAME_NO_GLOBALS}>
             GAME_NO_VARIABLES=$<BOOL:${GAME_NO_VARIABLES}>
@@ -226,13 +226,13 @@ if(WITH_RSDK)
     else() # None Gametype
         target_compile_definitions(${GAME_NAME} PRIVATE
             RETRO_REVISION=${RETRO_REVISION}
-	    
+
             RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
             RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
-        
+
             GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
             GAME_VERSION=${GAME_VERSION}
-	    
+
             GAME_TYPE=${GAME_TYPE}
             GAME_NO_GLOBALS=$<BOOL:${GAME_NO_GLOBALS}>
             GAME_NO_VARIABLES=$<BOOL:${GAME_NO_VARIABLES}>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,10 @@ if(WITH_RSDK)
         set(GAME_TYPE 1)
     endif()
 
+    if(NOT DEFINED GAMEAPI_INC)
+        set(GAMEAPI_INC <GameObjects.h>)
+    endif()
+
     target_compile_definitions(${GAME_NAME} PRIVATE
         RETRO_REVISION=${RETRO_REVISION}
 
@@ -188,6 +192,7 @@ if(WITH_RSDK)
         GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
         GAME_VERSION=${GAME_VERSION}
         GAME_TYPE=${GAME_TYPE}
+        GAMEAPI_INC=${GAMEAPI_INC}
     )
 
     if(DEFINED GAME_NO_GLOBALS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,10 +179,6 @@ if(WITH_RSDK)
         set(GAME_TYPE 1)
     endif()
 
-    if(NOT DEFINED GAMEAPI_INC)
-        set(GAMEAPI_INC <GameObjects.h>)
-    endif()
-
     target_compile_definitions(${GAME_NAME} PRIVATE
         RETRO_REVISION=${RETRO_REVISION}
 
@@ -192,7 +188,6 @@ if(WITH_RSDK)
         GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
         GAME_VERSION=${GAME_VERSION}
         GAME_TYPE=${GAME_TYPE}
-        GAMEAPI_INC=${GAMEAPI_INC}
     )
 
     if(DEFINED GAME_NO_GLOBALS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,72 +171,46 @@ if(WITH_RSDK)
             $<TARGET_FILE_DIR:RetroEngine>)
     endif()
 
+    if(NOT DEFINED GAME_VERSION)
+        set(GAME_VERSION 0)
+    endif()
+
     if(NOT DEFINED GAME_TYPE)
         set(GAME_TYPE 1)
     endif()
 
-    if(NOT DEFINED GAME_NO_GLOBALS)
-        set(GAME_NO_GLOBALS OFF)
+    target_compile_definitions(${GAME_NAME} PRIVATE
+        RETRO_REVISION=${RETRO_REVISION}
+
+        RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
+        RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
+
+        GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
+        GAME_VERSION=${GAME_VERSION}
+        GAME_TYPE=${GAME_TYPE}
+    )
+
+    if(DEFINED GAME_NO_GLOBALS)
+        target_compile_definitions(${GAME_NAME} PRIVATE GAME_NO_GLOBALS)
     endif()
 
-    if(NOT DEFINED GAME_NO_VARIABLES)
-        set(GAME_NO_VARIABLES OFF)
+    if(DEFINED GAME_NO_VARIABLES)
+        target_compile_definitions(${GAME_NAME} PRIVATE GAME_NO_VARIABLES)
     endif()
 
-    if(NOT DEFINED GAME_CUSTOMLINKLOGIC)
-        set(GAME_CUSTOMLINKLOGIC OFF)
+    if(DEFINED GAME_CUSTOMLINKLOGIC)
+        target_compile_definitions(${GAME_NAME} PRIVATE GAME_CUSTOMLINKLOGIC=$<BOOL:${GAME_CUSTOMLINKLOGIC}>)
     endif()
 
     if (GAME_TYPE STREQUAL "1") # Sonic Mania
         target_compile_definitions(${GAME_NAME} PRIVATE
-            RETRO_REVISION=${RETRO_REVISION}
-
-            RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
-            RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
-
-            GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
-            GAME_VERSION=${GAME_VERSION}
-
             MANIA_PREPLUS=$<BOOL:${MANIA_PREPLUS}>
             MANIA_FIRST_RELEASE=$<BOOL:${MANIA_FIRST_RELEASE}>
-
-            GAME_TYPE=${GAME_TYPE}
-            GAME_NO_GLOBALS=$<BOOL:${GAME_NO_GLOBALS}>
-            GAME_NO_VARIABLES=$<BOOL:${GAME_NO_VARIABLES}>
-            GAME_CUSTOMLINKLOGIC=$<BOOL:${GAME_CUSTOMLINKLOGIC}>
         )
     elseif(GAME_TYPE STREQUAL "2") # Sonic 3 & Knuckles
         target_compile_definitions(${GAME_NAME} PRIVATE
-            RETRO_REVISION=${RETRO_REVISION}
-
-            RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
-            RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
-
-            GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
-            GAME_VERSION=${GAME_VERSION}
-
             ORIGINS_PREPLUS=$<BOOL:${ORIGINS_PREPLUS}>
             ORIGINS_FIRST_RELEASE=$<BOOL:${ORIGINS_FIRST_RELEASE}>
-
-            GAME_TYPE=${GAME_TYPE}
-            GAME_NO_GLOBALS=$<BOOL:${GAME_NO_GLOBALS}>
-            GAME_NO_VARIABLES=$<BOOL:${GAME_NO_VARIABLES}>
-            GAME_CUSTOMLINKLOGIC=$<BOOL:${GAME_CUSTOMLINKLOGIC}>
-        )
-    else() # None Gametype
-        target_compile_definitions(${GAME_NAME} PRIVATE
-            RETRO_REVISION=${RETRO_REVISION}
-
-            RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
-            RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
-
-            GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
-            GAME_VERSION=${GAME_VERSION}
-
-            GAME_TYPE=${GAME_TYPE}
-            GAME_NO_GLOBALS=$<BOOL:${GAME_NO_GLOBALS}>
-            GAME_NO_VARIABLES=$<BOOL:${GAME_NO_VARIABLES}>
-            GAME_CUSTOMLINKLOGIC=$<BOOL:${GAME_CUSTOMLINKLOGIC}>
         )
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,16 +171,72 @@ if(WITH_RSDK)
             $<TARGET_FILE_DIR:RetroEngine>)
     endif()
 
-    target_compile_definitions(${GAME_NAME} PRIVATE
-        RETRO_REVISION=${RETRO_REVISION}
+    if(NOT DEFINED GAME_TYPE)
+        set(GAME_TYPE 1)
+    endif()
 
-        RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
-        RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
-    
-        GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
+    if(NOT DEFINED GAME_NO_GLOBALS)
+        set(GAME_NO_GLOBALS OFF)
+    endif()
 
-        MANIA_PREPLUS=$<BOOL:${MANIA_PREPLUS}>
-        MANIA_FIRST_RELEASE=$<BOOL:${MANIA_FIRST_RELEASE}>
-        GAME_VERSION=${GAME_VERSION}
-    )
+    if(NOT DEFINED GAME_NO_VARIABLES)
+        set(GAME_NO_VARIABLES OFF)
+    endif()
+
+    if(NOT DEFINED GAME_CUSTOMLINKLOGIC)
+        set(GAME_CUSTOMLINKLOGIC OFF)
+    endif()
+
+    if (GAME_TYPE STREQUAL "1") # Sonic Mania
+        target_compile_definitions(${GAME_NAME} PRIVATE
+            RETRO_REVISION=${RETRO_REVISION}
+	    
+            RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
+            RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
+        
+            GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
+            GAME_VERSION=${GAME_VERSION}
+	    
+            MANIA_PREPLUS=$<BOOL:${MANIA_PREPLUS}>
+            MANIA_FIRST_RELEASE=$<BOOL:${MANIA_FIRST_RELEASE}>
+	    
+            GAME_TYPE=${GAME_TYPE}
+            GAME_NO_GLOBALS=$<BOOL:${GAME_NO_GLOBALS}>
+            GAME_NO_VARIABLES=$<BOOL:${GAME_NO_VARIABLES}>
+            GAME_CUSTOMLINKLOGIC=$<BOOL:${GAME_CUSTOMLINKLOGIC}>
+        )
+    elseif(GAME_TYPE STREQUAL "2") # Sonic 3 & Knuckles
+        target_compile_definitions(${GAME_NAME} PRIVATE
+            RETRO_REVISION=${RETRO_REVISION}
+	    
+            RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
+            RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
+        
+            GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
+            GAME_VERSION=${GAME_VERSION}
+	    
+            ORIGINS_PREPLUS=$<BOOL:${ORIGINS_PREPLUS}>
+            ORIGINS_FIRST_RELEASE=$<BOOL:${ORIGINS_FIRST_RELEASE}>
+	    
+            GAME_TYPE=${GAME_TYPE}
+            GAME_NO_GLOBALS=$<BOOL:${GAME_NO_GLOBALS}>
+            GAME_NO_VARIABLES=$<BOOL:${GAME_NO_VARIABLES}>
+            GAME_CUSTOMLINKLOGIC=$<BOOL:${GAME_CUSTOMLINKLOGIC}>
+        )
+    else() # None Gametype
+        target_compile_definitions(${GAME_NAME} PRIVATE
+            RETRO_REVISION=${RETRO_REVISION}
+	    
+            RETRO_USE_MOD_LOADER=$<BOOL:${RETRO_MOD_LOADER}>
+            RETRO_MOD_LOADER_VER=${RETRO_MOD_LOADER_VER}
+        
+            GAME_INCLUDE_EDITOR=$<BOOL:${GAME_INCLUDE_EDITOR}>
+            GAME_VERSION=${GAME_VERSION}
+	    
+            GAME_TYPE=${GAME_TYPE}
+            GAME_NO_GLOBALS=$<BOOL:${GAME_NO_GLOBALS}>
+            GAME_NO_VARIABLES=$<BOOL:${GAME_NO_VARIABLES}>
+            GAME_CUSTOMLINKLOGIC=$<BOOL:${GAME_CUSTOMLINKLOGIC}>
+        )
+    endif()
 endif()

--- a/RSDKv5/main.cpp
+++ b/RSDKv5/main.cpp
@@ -5,10 +5,7 @@
 #define LinkGameLogic RSDK::LinkGameLogic
 #else
 #define EngineInfo RSDK::EngineInfo
-#ifndef GAMEAPI_INC
-#define GAMEAPI_INC <GameObjects.h>
-#endif
-#include GAMEAPI_INC
+#include <GameObjects.h>
 #define LinkGameLogic LinkGameLogicDLL
 #endif
 

--- a/RSDKv5/main.cpp
+++ b/RSDKv5/main.cpp
@@ -5,7 +5,7 @@
 #define LinkGameLogic RSDK::LinkGameLogic
 #else
 #define EngineInfo RSDK::EngineInfo
-#include <GameMain.h>
+#include <GameObjects.h>
 #define LinkGameLogic LinkGameLogicDLL
 #endif
 

--- a/RSDKv5/main.cpp
+++ b/RSDKv5/main.cpp
@@ -5,7 +5,10 @@
 #define LinkGameLogic RSDK::LinkGameLogic
 #else
 #define EngineInfo RSDK::EngineInfo
-#include <GameObjects.h>
+#ifndef GAMEAPI_INC
+#define GAMEAPI_INC <GameObjects.h>
+#endif
+#include GAMEAPI_INC
 #define LinkGameLogic LinkGameLogicDLL
 #endif
 


### PR DESCRIPTION
Allows building static binaries for any game that uses [GameAPI](https://github.com/RSDKModding/RSDKv5-GameAPI), rather than just Sonic Mania.

Depends on RSDKModding/Sonic-Mania-Decompilation#301.